### PR TITLE
Potential fix for code scanning alert no. 1: Overly permissive file permissions

### DIFF
--- a/caspoon/tests/unit/test_edge_cases.py
+++ b/caspoon/tests/unit/test_edge_cases.py
@@ -121,8 +121,8 @@ class TestEdgeCases:
             # Should handle permission errors gracefully
             assert isinstance(report, ExecutableReport)
         finally:
-            # Restore permissions for cleanup
-            os.chmod(no_perm, 0o644)
+            # Restore permissions for cleanup (owner read/write only)
+            os.chmod(no_perm, 0o600)
 
     def test_unicode_in_path(self, tmp_path):
         """Test handling of unicode characters in path."""


### PR DESCRIPTION
Potential fix for [https://github.com/LosEvons/spoons16/security/code-scanning/1](https://github.com/LosEvons/spoons16/security/code-scanning/1)

To fix the problem, we should restore the file’s permissions to a restrictive mode that only allows the owner to read and write, e.g., `0o600`, instead of making it world-readable (`0o644`). This maintains the intended functionality—ensuring the file is accessible again for cleanup—while removing unnecessary access for group and others.

Concretely, in `caspoon/tests/unit/test_edge_cases.py`, within `test_binary_with_no_permissions`, change the `os.chmod(no_perm, 0o644)` call in the `finally` block to `os.chmod(no_perm, 0o600)`. No additional imports or helper methods are needed, since `os` is already imported in this test method and `chmod` is standard. This preserves the behavior (the test file becomes readable/writable by the owner so pytest can delete it) but aligns with the recommendation to avoid world-readable permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
