### PR TITLE
Update tests to use widget ID constants and public APIs

### DIFF
--- a/caspoon/tests/helpers.py
+++ b/caspoon/tests/helpers.py
@@ -13,6 +13,22 @@ if TYPE_CHECKING:
     from textual.pilot import Pilot
 
 
+def _is_busy(app: App) -> bool:
+    """Check whether the app still has work in progress.
+
+    Checks both Textual's built-in worker set and the custom
+    ``is_analyzing`` flag used by CaspoonApp.
+    """
+    if app.workers:
+        return True
+    state = getattr(app, "state", None)
+    if state is not None:
+        ui_state = getattr(state, "ui_state", None)
+        if ui_state is not None and getattr(ui_state, "is_analyzing", False):
+            return True
+    return False
+
+
 async def wait_for_workers(
     app: App,
     pilot: Pilot,
@@ -22,8 +38,9 @@ async def wait_for_workers(
 ) -> None:
     """Wait for all background workers to complete.
 
-    Polls ``app.workers`` until the set is empty, draining the Textual
-    message queue between polls so the UI can process completion messages.
+    Polls both ``app.workers`` (Textual workers) and
+    ``app.state.ui_state.is_analyzing`` (custom analysis worker) until
+    idle, draining the message queue between polls.
 
     Args:
         app: The Textual application instance.
@@ -35,7 +52,7 @@ async def wait_for_workers(
         TimeoutError: If workers are still running after *timeout* seconds.
     """
     elapsed = 0.0
-    while app.workers:
+    while _is_busy(app):
         await pilot.pause()
         await asyncio.sleep(poll_interval)
         elapsed += poll_interval
@@ -71,14 +88,4 @@ async def start_analysis_and_wait(
     await app.start_analysis(path)
     await pilot.pause()
 
-    elapsed = 0.0
-    poll = 0.05
-    while getattr(app.state.ui_state, "is_analyzing", False) or app.workers:
-        await pilot.pause()
-        await asyncio.sleep(poll)
-        elapsed += poll
-        if elapsed >= timeout:
-            raise TimeoutError(
-                f"Analysis still running after {timeout}s"
-            )
-    await pilot.pause()
+    await wait_for_workers(app, pilot, timeout=timeout)

--- a/caspoon/tests/integration/ui/test_async_analysis.py
+++ b/caspoon/tests/integration/ui/test_async_analysis.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from textual.widgets import Input
 
+from caspoon.tests.helpers import wait_for_workers
 from caspoon.ui.app import CaspoonApp
 from caspoon.ui.core.messages import AnalysisComplete, ProgressUpdate, StartAnalysis
 
@@ -57,7 +58,7 @@ class TestAsyncAnalysisIntegration:
             # Start analysis
             async with app.run_test() as pilot:
                 await app.start_analysis(temp_binary)
-                await asyncio.sleep(0.05)  # Shorter wait to check before completion
+                await wait_for_workers(app, pilot)
 
                 # Check state - should be analyzing or just completed
                 assert app.state.ui_state.analysis_progress >= 0
@@ -85,7 +86,7 @@ class TestAsyncAnalysisIntegration:
 
             async with app.run_test() as pilot:
                 await app.start_analysis(temp_binary)
-                await pilot.pause(0.2)  # Wait for analysis
+                await pilot.pause()  # Drain message queue
 
                 # At minimum, some progress should have been reported
                 # The worker posts progress at 10%, 30%, and 100%
@@ -104,7 +105,7 @@ class TestAsyncAnalysisIntegration:
 
             async with app.run_test() as pilot:
                 await app.start_analysis(temp_binary)
-                await asyncio.sleep(0.15)  # Wait for completion
+                await wait_for_workers(app, pilot)
 
                 # Check state was updated
                 assert app.state.binary_info is not None
@@ -130,7 +131,7 @@ class TestAsyncAnalysisIntegration:
             with patch("asyncio.to_thread", side_effect=slow_analysis):
                 async with app.run_test() as pilot:
                     await app.start_analysis(temp_binary)
-                    await asyncio.sleep(0.05)  # Let it start
+                    await pilot.pause()  # Drain messages
 
                     # Check it's running
                     assert app.state.ui_state.is_analyzing is True
@@ -157,7 +158,7 @@ class TestAsyncAnalysisIntegration:
                 await app.start_analysis(temp_binary)
                 first_worker = app._current_worker
 
-                await asyncio.sleep(0.05)
+                await pilot.pause()
 
                 # Start second analysis (should cancel first)
                 await app.start_analysis(temp_binary)
@@ -166,7 +167,7 @@ class TestAsyncAnalysisIntegration:
                 # Should be different workers
                 assert first_worker is not second_worker
 
-                await asyncio.sleep(0.15)
+                await wait_for_workers(app, pilot)
 
                 # Should complete successfully
                 assert app.state.ui_state.is_analyzing is False
@@ -183,7 +184,7 @@ class TestAsyncAnalysisIntegration:
 
             async with app.run_test() as pilot:
                 await app.start_analysis(temp_binary)
-                await asyncio.sleep(0.15)  # Wait for error
+                await wait_for_workers(app, pilot)
 
                 # Check error was handled
                 assert app.state.ui_state.is_analyzing is False
@@ -196,7 +197,7 @@ class TestAsyncAnalysisIntegration:
 
         async with app.run_test() as pilot:
             await app.start_analysis("/nonexistent/file")
-            await asyncio.sleep(0.1)  # Wait for error
+            await wait_for_workers(app, pilot)
 
             # Check error was handled
             assert app.state.ui_state.is_analyzing is False
@@ -228,7 +229,7 @@ class TestAsyncAnalysisIntegration:
                     assert input_widget is not None
 
                     # Wait for completion
-                    await asyncio.sleep(0.3)
+                    await wait_for_workers(app, pilot)
 
                     assert app.state.ui_state.is_analyzing is False
 
@@ -249,7 +250,7 @@ class TestMessageBasedAnalysis:
             async with app.run_test() as pilot:
                 # Post StartAnalysis message
                 app.post_message(StartAnalysis(temp_binary))
-                await asyncio.sleep(0.15)  # Wait for processing
+                await wait_for_workers(app, pilot)
 
                 # Check analysis ran
                 assert app.state.binary_info is not None
@@ -278,13 +279,13 @@ class TestStateManagement:
             with patch("asyncio.to_thread", side_effect=slow_analysis):
                 async with app.run_test() as pilot:
                     await app.start_analysis(temp_binary)
-                    await asyncio.sleep(0.05)  # Let it start
+                    await pilot.pause()  # Drain messages
 
                     # Check flag is set
                     assert app.state.ui_state.is_analyzing is True
 
                     # Wait for completion
-                    await asyncio.sleep(0.3)
+                    await wait_for_workers(app, pilot)
 
                     # Check flag is cleared
                     assert app.state.ui_state.is_analyzing is False
@@ -301,15 +302,13 @@ class TestStateManagement:
 
             async with app.run_test() as pilot:
                 await app.start_analysis(temp_binary)
-
-                # Wait a bit and check progress
-                await asyncio.sleep(0.05)
+                await pilot.pause()
 
                 # Progress should be > 0
                 assert app.state.ui_state.analysis_progress >= 0
 
                 # Wait for completion
-                await asyncio.sleep(0.15)
+                await wait_for_workers(app, pilot)
 
                 # Progress should be 100
                 assert app.state.ui_state.analysis_progress == 100
@@ -330,13 +329,7 @@ class TestStatusDisplay:
 
             async with app.run_test() as pilot:
                 await app.start_analysis(temp_binary)
-                await asyncio.sleep(0.05)
-
-                # Status should contain "Analyzing"
-                # (We'd need to query the footer to check this properly,
-                # but update_status is called which sets it)
-
-                await asyncio.sleep(0.15)
+                await wait_for_workers(app, pilot)
 
                 # After completion, should show "Ready" or similar
 
@@ -352,7 +345,7 @@ class TestStatusDisplay:
 
             async with app.run_test() as pilot:
                 await app.start_analysis(temp_binary)
-                await asyncio.sleep(0.15)
+                await wait_for_workers(app, pilot)
 
                 # Check state is reset
                 assert app.state.ui_state.is_analyzing is False

--- a/caspoon/tests/integration/ui/test_command_palette_integration.py
+++ b/caspoon/tests/integration/ui/test_command_palette_integration.py
@@ -3,6 +3,7 @@
 import pytest
 from textual.widgets import Input
 
+from caspoon.ui import widget_ids as wid
 from caspoon.ui.app import CaspoonApp
 from caspoon.ui.widgets.command_palette import CommandPalette
 
@@ -17,7 +18,7 @@ class TestCommandPaletteIntegration:
 
         async with app.run_test() as pilot:
             # Initially palette should not be visible
-            palette = app.query_one("#command_palette", CommandPalette)
+            palette = app.query_one(f"#{wid.COMMAND_PALETTE}", CommandPalette)
             assert not palette.has_class("visible")
 
             # Trigger show command palette action
@@ -39,11 +40,11 @@ class TestCommandPaletteIntegration:
 
             await pilot.pause()
 
-            palette = app.query_one("#command_palette", CommandPalette)
+            palette = app.query_one(f"#{wid.COMMAND_PALETTE}", CommandPalette)
             assert palette.has_class("visible")
 
             # Search for quit command
-            search_input = palette.query_one("#search", Input)
+            search_input = palette.query_one(f"#{wid.COMMAND_SEARCH}", Input)
             search_input.value = "quit"
 
             await pilot.pause()
@@ -68,16 +69,16 @@ class TestCommandPaletteIntegration:
 
             await pilot.pause()
 
-            palette = app.query_one("#command_palette", CommandPalette)
+            palette = app.query_one(f"#{wid.COMMAND_PALETTE}", CommandPalette)
 
             # Search for "overview"
-            search_input = palette.query_one("#search", Input)
+            search_input = palette.query_one(f"#{wid.COMMAND_SEARCH}", Input)
             search_input.value = "overview"
 
             await pilot.pause()
 
             # Should find the "Show Overview" command
-            results = palette.query_one("#results")
+            results = palette.query_one(f"#{wid.COMMAND_RESULTS}")
             assert len(results.children) >= 1
 
     @pytest.mark.asyncio
@@ -91,17 +92,17 @@ class TestCommandPaletteIntegration:
 
             await pilot.pause()
 
-            palette = app.query_one("#command_palette", CommandPalette)
+            palette = app.query_one(f"#{wid.COMMAND_PALETTE}", CommandPalette)
             assert palette.has_class("visible")
 
             # Type to search
-            search_input = palette.query_one("#search", Input)
+            search_input = palette.query_one(f"#{wid.COMMAND_SEARCH}", Input)
             search_input.value = "help"
 
             await pilot.pause()
 
             # Results should be filtered
-            results = palette.query_one("#results")
+            results = palette.query_one(f"#{wid.COMMAND_RESULTS}")
             assert len(results.children) >= 1
 
             # Close with escape
@@ -123,10 +124,10 @@ class TestCommandPaletteIntegration:
 
             await pilot.pause()
 
-            palette = app.query_one("#command_palette", CommandPalette)
+            palette = app.query_one(f"#{wid.COMMAND_PALETTE}", CommandPalette)
 
             # Search for help command
-            search_input = palette.query_one("#search", Input)
+            search_input = palette.query_one(f"#{wid.COMMAND_SEARCH}", Input)
             search_input.value = "help"
 
             await pilot.pause()
@@ -169,15 +170,15 @@ class TestCommandPaletteIntegration:
 
             await pilot.pause()
 
-            palette = app.query_one("#command_palette", CommandPalette)
+            palette = app.query_one(f"#{wid.COMMAND_PALETTE}", CommandPalette)
 
             # Search for "view" (should match category)
-            search_input = palette.query_one("#search", Input)
+            search_input = palette.query_one(f"#{wid.COMMAND_SEARCH}", Input)
             search_input.value = "view"
 
             await pilot.pause()
 
-            results = palette.query_one("#results")
+            results = palette.query_one(f"#{wid.COMMAND_RESULTS}")
             # Should find multiple view commands
             assert len(results.children) >= 3
 
@@ -192,15 +193,15 @@ class TestCommandPaletteIntegration:
 
             await pilot.pause()
 
-            palette = app.query_one("#command_palette", CommandPalette)
+            palette = app.query_one(f"#{wid.COMMAND_PALETTE}", CommandPalette)
 
             # Search for a command with a keybinding
-            search_input = palette.query_one("#search", Input)
+            search_input = palette.query_one(f"#{wid.COMMAND_SEARCH}", Input)
             search_input.value = "quit"
 
             await pilot.pause()
 
-            results = palette.query_one("#results")
+            results = palette.query_one(f"#{wid.COMMAND_RESULTS}")
             # Should have at least one result
             assert len(results.children) >= 1
 
@@ -215,10 +216,10 @@ class TestCommandPaletteIntegration:
 
             await pilot.pause()
 
-            palette = app.query_one("#command_palette", CommandPalette)
+            palette = app.query_one(f"#{wid.COMMAND_PALETTE}", CommandPalette)
 
             # Set some search text
-            search_input = palette.query_one("#search", Input)
+            search_input = palette.query_one(f"#{wid.COMMAND_SEARCH}", Input)
             search_input.value = "test"
 
             await pilot.pause()
@@ -245,7 +246,7 @@ class TestCommandPaletteIntegration:
             # Get all registered actions
             all_actions = app.action_registry.get_all_actions()
 
-            palette = app.query_one("#command_palette", CommandPalette)
+            palette = app.query_one(f"#{wid.COMMAND_PALETTE}", CommandPalette)
 
             # Test a few key commands
             test_commands = [
@@ -258,12 +259,12 @@ class TestCommandPaletteIntegration:
                 palette.show()
                 await pilot.pause()
 
-                search_input = palette.query_one("#search", Input)
+                search_input = palette.query_one(f"#{wid.COMMAND_SEARCH}", Input)
                 search_input.value = query
 
                 await pilot.pause()
 
-                results = palette.query_one("#results")
+                results = palette.query_one(f"#{wid.COMMAND_RESULTS}")
                 # Should find the command - check the action_id attribute
                 assert any(
                     getattr(child, "action_id", None) == expected_id

--- a/caspoon/tests/integration/ui/test_core_views_integration.py
+++ b/caspoon/tests/integration/ui/test_core_views_integration.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from caspoon.core.models import ExecutableReport, ProtectionInfo
+from caspoon.ui import widget_ids as wid
 from caspoon.tests.fixtures.ui_fixtures import (
     mock_executable_report,
 )
@@ -51,7 +52,7 @@ class TestViewsUpdateOnAnalysis:
 
         async with app.run_test() as pilot:
             # Get the OverviewView from the app
-            overview = app.query_one("#overview", OverviewView)
+            overview = app.query_one(f"#{wid.OVERVIEW_VIEW}", OverviewView)
 
             # Initially should have no data
             assert overview.data is None
@@ -74,7 +75,7 @@ class TestViewsUpdateOnAnalysis:
 
         async with app.run_test() as pilot:
             # Get the ProtectionsView from the app
-            protections = app.query_one("#protections", ProtectionsView)
+            protections = app.query_one(f"#{wid.PROTECTIONS_VIEW}", ProtectionsView)
 
             # Simulate analysis by updating state
             app.state.update_from_report(mock_executable_report)
@@ -93,8 +94,8 @@ class TestViewsUpdateOnAnalysis:
         app = CaspoonApp()
 
         async with app.run_test() as pilot:
-            overview = app.query_one("#overview", OverviewView)
-            protections = app.query_one("#protections", ProtectionsView)
+            overview = app.query_one(f"#{wid.OVERVIEW_VIEW}", OverviewView)
+            protections = app.query_one(f"#{wid.PROTECTIONS_VIEW}", ProtectionsView)
 
             # Both should start empty
             assert overview.data is None
@@ -198,8 +199,8 @@ class TestEndToEndFlow:
 
             async with app.run_test() as pilot:
                 # Get input widget and views
-                input_widget = app.query_one("#path_input")
-                overview = app.query_one("#overview", OverviewView)
+                input_widget = app.query_one(f"#{wid.PATH_INPUT}")
+                overview = app.query_one(f"#{wid.OVERVIEW_VIEW}", OverviewView)
 
                 # Initially views have no data
                 assert overview.data is None
@@ -250,7 +251,7 @@ class TestViewsWithoutState:
             await pilot.pause()
 
             # View should exist but have no data
-            overview = app.query_one("#overview", OverviewView)
+            overview = app.query_one(f"#{wid.OVERVIEW_VIEW}", OverviewView)
             assert overview is not None
 
 
@@ -263,7 +264,7 @@ class TestMultipleStateUpdates:
         app = CaspoonApp()
 
         async with app.run_test() as pilot:
-            overview = app.query_one("#overview", OverviewView)
+            overview = app.query_one(f"#{wid.OVERVIEW_VIEW}", OverviewView)
 
             # First report
             report1 = ExecutableReport(

--- a/caspoon/tests/integration/ui/test_empty_data_handling.py
+++ b/caspoon/tests/integration/ui/test_empty_data_handling.py
@@ -45,7 +45,7 @@ class TestEmptyDataHandling:
         # Should show "No strings" or similar message
         rendered = str(view.renderable)
         # The view should indicate no results
-        assert len(view._filtered) == 0
+        assert view.filtered_count == 0
 
     def test_imports_exports_view_empty_imports(self):
         """ImportsExportsView should show 'No imports' when empty."""
@@ -178,9 +178,9 @@ class TestEmptyDataWorkflows:
     @pytest.mark.asyncio
     async def test_empty_analysis_results(self):
         """Test handling of analysis with no interesting data."""
-        import asyncio
         from unittest.mock import patch
 
+        from caspoon.tests.helpers import wait_for_workers
         from caspoon.ui.app import CaspoonApp
 
         app = CaspoonApp()
@@ -215,7 +215,7 @@ class TestEmptyDataWorkflows:
                     temp_path = f.name
 
                 await app.start_analysis(temp_path)
-                await asyncio.sleep(0.2)
+                await wait_for_workers(app, pilot)
 
                 # Verify analysis completed
                 assert app.state.binary_info is not None
@@ -223,15 +223,15 @@ class TestEmptyDataWorkflows:
 
                 # Navigate to strings view - should show empty message
                 await pilot.press("3")
-                await pilot.pause(0.05)
+                await pilot.pause()
 
                 strings_view = app.query_one(StringsView)
-                assert len(strings_view._strings) == 0
+                assert strings_view.total_count == 0
                 # View should handle empty gracefully
 
                 # Navigate to imports/exports view
                 await pilot.press("4")
-                await pilot.pause(0.05)
+                await pilot.pause()
 
                 # Should not crash with empty data
                 assert app.state.analysis_results is not None

--- a/caspoon/tests/integration/ui/test_full_workflows.py
+++ b/caspoon/tests/integration/ui/test_full_workflows.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from caspoon.tests.helpers import wait_for_workers
 from caspoon.ui.app import CaspoonApp
 from caspoon.ui.views.strings_view import StringsView
 from caspoon.ui.widgets.command_palette import CommandPalette
@@ -100,7 +101,7 @@ class TestCompleteAnalysisWorkflow:
             async with app.run_test() as pilot:
                 # Step 1: Load binary
                 await app.start_analysis(temp_binary)
-                await asyncio.sleep(0.2)  # Wait for analysis
+                await wait_for_workers(app, pilot)
 
                 # Step 2: Verify analysis completed
                 assert app.state.binary_info is not None
@@ -112,11 +113,11 @@ class TestCompleteAnalysisWorkflow:
 
                 # Step 3: Navigate to strings view (Tab 3)
                 await pilot.press("3")
-                await pilot.pause(0.05)
+                await pilot.pause()
 
                 # Step 4: Verify strings view has data
                 strings_view = app.query_one(StringsView)
-                assert len(strings_view._strings) > 0
+                assert strings_view.total_count > 0
 
                 # Step 5: Apply filter to find "password"
                 # In a real UI test, we'd focus the filter input and type
@@ -124,14 +125,14 @@ class TestCompleteAnalysisWorkflow:
                 strings_view.apply_filter("password")
 
                 # Step 6: Verify filtering worked
-                assert any("password" in s.lower() for s in strings_view._filtered)
-                assert len(strings_view._filtered) < len(strings_view._strings)
+                assert any("password" in s.lower() for s in strings_view.filtered_strings)
+                assert strings_view.filtered_count < strings_view.total_count
 
                 # Step 7: Navigate to other views
                 await pilot.press("1")  # Overview
-                await pilot.pause(0.05)
+                await pilot.pause()
                 await pilot.press("2")  # Protections
-                await pilot.pause(0.05)
+                await pilot.pause()
 
                 # Step 8: Verify state persists across view changes
                 assert app.state.binary_info is not None
@@ -161,11 +162,11 @@ class TestCommandPaletteWorkflow:
             async with app.run_test() as pilot:
                 # Load binary first
                 await app.start_analysis(temp_binary)
-                await asyncio.sleep(0.2)
+                await wait_for_workers(app, pilot)
 
                 # Open command palette
                 await pilot.press("ctrl+p")
-                await pilot.pause(0.05)
+                await pilot.pause()
 
                 # Verify palette is visible
                 try:
@@ -177,7 +178,7 @@ class TestCommandPaletteWorkflow:
 
                 # Close palette (ESC)
                 await pilot.press("escape")
-                await pilot.pause(0.05)
+                await pilot.pause()
 
                 # Test that commands are registered
                 assert len(app.action_registry._actions) > 0
@@ -206,26 +207,26 @@ class TestMultiPanelWorkflow:
             async with app.run_test() as pilot:
                 # Load binary
                 await app.start_analysis(temp_binary)
-                await asyncio.sleep(0.2)
+                await wait_for_workers(app, pilot)
 
                 # Toggle sidebar (Ctrl+B)
                 initial_sidebar_state = app.state.ui_state.sidebar_visible
                 await pilot.press("ctrl+b")
-                await pilot.pause(0.05)
+                await pilot.pause()
 
                 # Verify sidebar state toggled (if toggle action is implemented)
                 # Note: The actual toggle might not change state in test without proper screen
                 # Just verify we can press the key without crashing
                 await pilot.press("ctrl+b")
-                await pilot.pause(0.05)
+                await pilot.pause()
 
                 # Toggle details panel (Ctrl+D)
                 await pilot.press("ctrl+d")
-                await pilot.pause(0.05)
+                await pilot.pause()
 
                 # Toggle console (Ctrl+J)
                 await pilot.press("ctrl+j")
-                await pilot.pause(0.05)
+                await pilot.pause()
 
                 # Verify state persists
                 assert app.state.binary_info is not None
@@ -249,7 +250,7 @@ class TestErrorHandlingWorkflow:
         async with app.run_test() as pilot:
             # Step 1: Try to load non-existent file
             await app.start_analysis("/nonexistent/file.bin")
-            await asyncio.sleep(0.1)
+            await wait_for_workers(app, pilot)
 
             # Step 2: Verify error was handled gracefully
             assert app.state.ui_state.is_analyzing is False
@@ -257,7 +258,7 @@ class TestErrorHandlingWorkflow:
 
             # Step 3: Verify app is still responsive
             await pilot.press("1")  # Should be able to switch tabs
-            await pilot.pause(0.05)
+            await pilot.pause()
 
             # Step 4: Load a valid file (with mocked analysis)
             with patch("caspoon.ui.workers.analysis.ReconRunner") as mock_runner_class:
@@ -281,7 +282,7 @@ class TestErrorHandlingWorkflow:
                     temp_path = f.name
 
                 await app.start_analysis(temp_path)
-                await asyncio.sleep(0.2)
+                await wait_for_workers(app, pilot)
 
                 # Step 5: Verify successful analysis after error recovery
                 assert app.state.binary_info is not None
@@ -319,7 +320,7 @@ class TestCancellationWorkflow:
                 async with app.run_test() as pilot:
                     # Step 1: Start analysis
                     await app.start_analysis(temp_binary)
-                    await asyncio.sleep(0.05)
+                    await pilot.pause()  # Drain messages, don't wait for completion
 
                     # Step 2: Verify it's running
                     assert app.state.ui_state.is_analyzing is True
@@ -328,7 +329,7 @@ class TestCancellationWorkflow:
 
                     # Step 3: Cancel analysis
                     await app.cancel_analysis()
-                    await asyncio.sleep(0.05)
+                    await pilot.pause()
 
                     # Step 4: Verify cleanup
                     assert app.state.ui_state.is_analyzing is False
@@ -336,7 +337,7 @@ class TestCancellationWorkflow:
 
                     # Step 5: Start new analysis (should work)
                     await app.start_analysis(temp_binary)
-                    await asyncio.sleep(0.05)
+                    await pilot.pause()
 
                     # Step 6: Verify new analysis started
                     second_worker = app._current_worker
@@ -370,16 +371,16 @@ class TestRapidOperationsWorkflow:
             async with app.run_test() as pilot:
                 # Load binary
                 await app.start_analysis(temp_binary)
-                await asyncio.sleep(0.2)
+                await wait_for_workers(app, pilot)
 
                 # Rapid tab switching
                 for _ in range(10):
                     await pilot.press("1")
-                    await pilot.pause(0.01)
+                    await pilot.pause()
                     await pilot.press("2")
-                    await pilot.pause(0.01)
+                    await pilot.pause()
                     await pilot.press("3")
-                    await pilot.pause(0.01)
+                    await pilot.pause()
 
                 # Verify app is still stable
                 assert app.state.binary_info is not None
@@ -387,9 +388,9 @@ class TestRapidOperationsWorkflow:
                 # Rapid command palette open/close
                 for _ in range(5):
                     await pilot.press("ctrl+p")
-                    await pilot.pause(0.02)
+                    await pilot.pause()
                     await pilot.press("escape")
-                    await pilot.pause(0.02)
+                    await pilot.pause()
 
                 # Verify no crashes
                 assert app.state.binary_info is not None
@@ -419,13 +420,13 @@ class TestViewSwitchingWorkflow:
             async with app.run_test() as pilot:
                 # Load binary
                 await app.start_analysis(temp_binary)
-                await asyncio.sleep(0.2)
+                await wait_for_workers(app, pilot)
 
                 # Navigate through all views
                 views = ["1", "2", "3", "4", "5"]
                 for view_key in views:
                     await pilot.press(view_key)
-                    await pilot.pause(0.05)
+                    await pilot.pause()
 
                     # Verify state is still intact
                     assert app.state.binary_info is not None
@@ -433,7 +434,7 @@ class TestViewSwitchingWorkflow:
 
                 # Go back to first view
                 await pilot.press("1")
-                await pilot.pause(0.05)
+                await pilot.pause()
 
                 # Verify data is still correct
                 assert app.state.binary_info.architecture == "x86_64"
@@ -463,29 +464,29 @@ class TestFilterWorkflow:
             async with app.run_test() as pilot:
                 # Load binary
                 await app.start_analysis(temp_binary)
-                await asyncio.sleep(0.2)
+                await wait_for_workers(app, pilot)
 
                 # Go to strings view
                 await pilot.press("3")
-                await pilot.pause(0.05)
+                await pilot.pause()
 
                 # Get strings view and test filtering
                 strings_view = app.query_one(StringsView)
 
                 # Test filter: "password"
                 strings_view.apply_filter("password")
-                filtered_count_1 = len(strings_view._filtered)
+                filtered_count_1 = strings_view.filtered_count
                 assert filtered_count_1 > 0
-                assert filtered_count_1 <= len(strings_view._strings)
+                assert filtered_count_1 <= strings_view.total_count
 
                 # Test filter: "admin"
                 strings_view.apply_filter("admin")
-                filtered_count_2 = len(strings_view._filtered)
+                filtered_count_2 = strings_view.filtered_count
                 assert filtered_count_2 >= 0
 
                 # Clear filter
                 strings_view.apply_filter("")
-                assert len(strings_view._filtered) == len(strings_view._strings)
+                assert strings_view.filtered_count == strings_view.total_count
 
                 # Verify state unchanged
                 assert app.state.analysis_results is not None
@@ -536,7 +537,7 @@ class TestMultipleAnalysesWorkflow:
             async with app.run_test() as pilot:
                 # Analyze first binary
                 await app.start_analysis(temp_binary)
-                await asyncio.sleep(0.2)
+                await wait_for_workers(app, pilot)
 
                 assert app.state.binary_info.path == "/test/binary1"
                 assert app.state.binary_info.architecture == "x86_64"
@@ -544,7 +545,7 @@ class TestMultipleAnalysesWorkflow:
 
                 # Analyze second binary
                 await app.start_analysis(temp_binary)
-                await asyncio.sleep(0.2)
+                await wait_for_workers(app, pilot)
 
                 # Verify new data replaced old data
                 assert app.state.binary_info.path == "/test/binary2"

--- a/caspoon/tests/integration/ui/test_multi_panel_layout.py
+++ b/caspoon/tests/integration/ui/test_multi_panel_layout.py
@@ -3,6 +3,7 @@
 import pytest
 from textual.app import App
 
+from caspoon.ui import widget_ids as wid
 from caspoon.ui.core.models import AnalysisResults
 from caspoon.ui.core.state import AppState
 from caspoon.ui.screens import MainScreen
@@ -35,16 +36,16 @@ class TestMultiPanelLayout:
 
             # Check all panels are present
             main_screen = test_app.query_one(MainScreen)
-            sidebar = main_screen.query_one("#sidebar", Sidebar)
+            sidebar = main_screen.query_one(f"#{wid.SIDEBAR}", Sidebar)
             assert sidebar is not None
 
-            details = main_screen.query_one("#details", DetailsPanel)
+            details = main_screen.query_one(f"#{wid.DETAILS}", DetailsPanel)
             assert details is not None
 
-            console = main_screen.query_one("#console", Console)
+            console = main_screen.query_one(f"#{wid.CONSOLE}", Console)
             assert console is not None
 
-            content_area = main_screen.query_one("#content")
+            content_area = main_screen.query_one(f"#{wid.CONTENT}")
             assert content_area is not None
 
     @pytest.mark.asyncio
@@ -133,8 +134,8 @@ class TestMultiPanelLayout:
 
             # Get function explorer from sidebar
             main_screen = test_app.query_one(MainScreen)
-            sidebar = main_screen.query_one("#sidebar", Sidebar)
-            explorer = sidebar._explorer
+            sidebar = main_screen.query_one(f"#{wid.SIDEBAR}", Sidebar)
+            explorer = sidebar.explorer
 
             # Set test data
             results = AnalysisResults(
@@ -163,7 +164,7 @@ class TestMultiPanelLayout:
 
             # Get details panel
             main_screen = test_app.query_one(MainScreen)
-            details = main_screen.query_one("#details", DetailsPanel)
+            details = main_screen.query_one(f"#{wid.DETAILS}", DetailsPanel)
 
             # Show function details
             func_data = {
@@ -195,7 +196,7 @@ class TestMultiPanelLayout:
             await pilot.pause()
 
             # Verify messages were logged
-            rich_log = console.query_one("#console_log")
+            rich_log = console.query_one(f"#{wid.CONSOLE_LOG}")
             assert len(rich_log.lines) >= 2
 
     @pytest.mark.asyncio

--- a/caspoon/tests/unit/ui/views/test_overview.py
+++ b/caspoon/tests/unit/ui/views/test_overview.py
@@ -4,6 +4,7 @@ import pytest
 from textual.app import App, ComposeResult
 
 from caspoon.core.models import ExecutableReport
+from caspoon.ui import widget_ids as wid
 from caspoon.tests.fixtures.ui_fixtures import (
     mock_app_state,
     mock_binary_info,
@@ -76,7 +77,7 @@ class TestOverviewViewStateSubscription:
         app.state.subscribe = mock_subscribe
 
         async with app.run_test() as pilot:
-            view = app.query_one("#overview", OverviewView)
+            view = app.query_one(f"#{wid.OVERVIEW_VIEW}", OverviewView)
 
             # Give time for on_mount to be called
             await pilot.pause()
@@ -92,7 +93,7 @@ class TestOverviewViewStateSubscription:
         app = CaspoonApp()
 
         async with app.run_test() as pilot:
-            view = app.query_one("#overview", OverviewView)
+            view = app.query_one(f"#{wid.OVERVIEW_VIEW}", OverviewView)
 
             # Verify initial state
             assert view.data is None

--- a/caspoon/tests/unit/ui/views/test_protections.py
+++ b/caspoon/tests/unit/ui/views/test_protections.py
@@ -3,6 +3,7 @@
 import pytest
 from textual.app import App, ComposeResult
 
+from caspoon.ui import widget_ids as wid
 from caspoon.tests.fixtures.ui_fixtures import (
     empty_protections_dict,
     full_protections_dict,
@@ -79,7 +80,7 @@ class TestProtectionsViewStateSubscription:
         app.state.subscribe = mock_subscribe
 
         async with app.run_test() as pilot:
-            view = app.query_one("#protections", ProtectionsView)
+            view = app.query_one(f"#{wid.PROTECTIONS_VIEW}", ProtectionsView)
 
             # Give time for on_mount to be called
             await pilot.pause()
@@ -95,7 +96,7 @@ class TestProtectionsViewStateSubscription:
         app = CaspoonApp()
 
         async with app.run_test() as pilot:
-            view = app.query_one("#protections", ProtectionsView)
+            view = app.query_one(f"#{wid.PROTECTIONS_VIEW}", ProtectionsView)
 
             # Update state - should trigger view update
             app.state.analysis_results = mock_analysis_results
@@ -277,7 +278,7 @@ class TestProtectionsViewEdgeCases:
         app = CaspoonApp()
 
         async with app.run_test() as pilot:
-            view = app.query_one("#protections", ProtectionsView)
+            view = app.query_one(f"#{wid.PROTECTIONS_VIEW}", ProtectionsView)
 
             # Set results to None - should clear view data
             app.state.analysis_results = None

--- a/caspoon/tests/unit/ui/views/test_strings_view.py
+++ b/caspoon/tests/unit/ui/views/test_strings_view.py
@@ -43,8 +43,8 @@ class TestStringsViewInitialization:
     def test_initializes_with_empty_strings(self):
         """Test that StringsView initializes with empty string lists."""
         view = StringsView()
-        assert view._strings == []
-        assert view._filtered == []
+        assert view.all_strings == []
+        assert view.filtered_strings == []
 
     def test_has_bindings(self):
         """Test that StringsView has keybindings defined."""
@@ -128,7 +128,7 @@ class TestStringsViewRendering:
         strings = ["string1", "string2", "string3"]
         view.render_content(strings)
 
-        assert view._strings == strings
+        assert view.all_strings == strings
 
     def test_render_content_with_empty_list(self):
         """Test that render_content handles empty list."""
@@ -137,8 +137,8 @@ class TestStringsViewRendering:
         # Should not raise
         view.render_content([])
 
-        assert view._strings == []
-        assert view._filtered == []
+        assert view.all_strings == []
+        assert view.filtered_strings == []
 
     def test_render_strings_shows_empty_message(self):
         """Test that empty strings list shows appropriate message."""
@@ -168,7 +168,7 @@ class TestStringsViewFiltering:
         view._strings = ["apple", "banana", "cherry"]
         view.apply_filter("")
 
-        assert view._filtered == ["apple", "banana", "cherry"]
+        assert view.filtered_strings == ["apple", "banana", "cherry"]
 
     def test_apply_filter_case_insensitive(self):
         """Test that apply_filter is case-insensitive."""
@@ -181,9 +181,9 @@ class TestStringsViewFiltering:
 
         view.apply_filter("apple")
 
-        assert len(view._filtered) == 2
-        assert "Apple" in view._filtered
-        assert "APPLE PIE" in view._filtered
+        assert view.filtered_count == 2
+        assert "Apple" in view.filtered_strings
+        assert "APPLE PIE" in view.filtered_strings
 
     def test_apply_filter_substring_match(self):
         """Test that apply_filter does substring matching."""
@@ -201,9 +201,9 @@ class TestStringsViewFiltering:
 
         view.apply_filter("test")
 
-        assert len(view._filtered) == 2
-        assert "/usr/bin/test" in view._filtered
-        assert "/var/log/test.log" in view._filtered
+        assert view.filtered_count == 2
+        assert "/usr/bin/test" in view.filtered_strings
+        assert "/var/log/test.log" in view.filtered_strings
 
     def test_apply_filter_resets_selection(self):
         """Test that apply_filter resets selection when needed."""
@@ -238,7 +238,7 @@ class TestStringsViewFiltering:
         view.filter_text = "ban"
 
         # Should filter strings
-        assert view._filtered == ["banana"]
+        assert view.filtered_strings == ["banana"]
 
     def test_action_clear_filter(self):
         """Test that action_clear_filter clears the filter."""
@@ -339,8 +339,8 @@ class TestStringsViewFilteredCountDisplay:
         # The output is a Panel, need to get title from Rich object
         panel = update_calls[0]
         # Check the filtered counts are correct
-        assert len(view._filtered) == 2
-        assert len(view._strings) == 4
+        assert view.filtered_count == 2
+        assert view.total_count == 4
 
     def test_filtered_count_in_title_no_filter(self):
         """Test that title shows total count when no filter."""
@@ -358,8 +358,8 @@ class TestStringsViewFilteredCountDisplay:
         # Check that title shows total count only
         assert len(update_calls) == 1
         # Check the counts are correct
-        assert len(view._filtered) == 3
-        assert len(view._strings) == 3
+        assert view.filtered_count == 3
+        assert view.total_count == 3
 
 
 class TestStringsViewBackwardCompatibility:
@@ -409,7 +409,7 @@ class TestStringsViewPerformance:
         # Should not raise and should complete reasonably fast
         view.render_content(large_string_list)
 
-        assert view._strings == large_string_list
+        assert view.all_strings == large_string_list
 
     def test_filtering_large_list(self):
         """Test that filtering works on large lists."""
@@ -426,7 +426,7 @@ class TestStringsViewPerformance:
         view.apply_filter("test")
 
         # Should find all test strings
-        assert len(view._filtered) == 5000
+        assert view.filtered_count == 5000
 
     def test_respects_max_display_limit(self):
         """Test that get_item_count respects MAX_DISPLAY_STRINGS."""

--- a/caspoon/tests/unit/ui/widgets/test_command_palette.py
+++ b/caspoon/tests/unit/ui/widgets/test_command_palette.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 import pytest
 from textual.widgets import Input, ListView
 
+from caspoon.ui import widget_ids as wid
 from caspoon.ui.core.actions import Action, ActionRegistry
 from caspoon.ui.widgets.command_palette import CommandPalette
 
@@ -105,8 +106,8 @@ class TestCommandPalette:
             palette = app.query_one("#palette", CommandPalette)
 
             # Check that Input and ListView are present
-            search_input = palette.query_one("#search", Input)
-            results_list = palette.query_one("#results", ListView)
+            search_input = palette.query_one(f"#{wid.COMMAND_SEARCH}", Input)
+            results_list = palette.query_one(f"#{wid.COMMAND_RESULTS}", ListView)
 
             assert search_input is not None
             assert results_list is not None
@@ -129,7 +130,7 @@ class TestCommandPalette:
 
             await pilot.pause()
 
-            results_list = palette.query_one("#results", ListView)
+            results_list = palette.query_one(f"#{wid.COMMAND_RESULTS}", ListView)
             # Should show all actions (7 registered)
             assert len(results_list.children) == 7
 
@@ -155,7 +156,7 @@ class TestCommandPalette:
             palette._update_results("file")
             await pilot.pause()
 
-            results_list = palette.query_one("#results", ListView)
+            results_list = palette.query_one(f"#{wid.COMMAND_RESULTS}", ListView)
             # Should show 3 file commands
             assert len(results_list.children) == 3
 
@@ -181,7 +182,7 @@ class TestCommandPalette:
             palette._update_results("clipboard")
             await pilot.pause()
 
-            results_list = palette.query_one("#results", ListView)
+            results_list = palette.query_one(f"#{wid.COMMAND_RESULTS}", ListView)
             # Should show copy and paste commands
             assert len(results_list.children) == 2
 
@@ -207,7 +208,7 @@ class TestCommandPalette:
             palette._update_results("view")
             await pilot.pause()
 
-            results_list = palette.query_one("#results", ListView)
+            results_list = palette.query_one(f"#{wid.COMMAND_RESULTS}", ListView)
             # Should show 2 view commands
             assert len(results_list.children) == 2
 
@@ -233,7 +234,7 @@ class TestCommandPalette:
             palette._update_results("FILE")
             await pilot.pause()
 
-            results_list = palette.query_one("#results", ListView)
+            results_list = palette.query_one(f"#{wid.COMMAND_RESULTS}", ListView)
             # Should still show 3 file commands
             assert len(results_list.children) == 3
 
@@ -265,7 +266,7 @@ class TestCommandPalette:
 
             await pilot.pause()
 
-            results_list = palette.query_one("#results", ListView)
+            results_list = palette.query_one(f"#{wid.COMMAND_RESULTS}", ListView)
             # Should show max 15 results
             assert len(results_list.children) <= 15
 
@@ -300,7 +301,7 @@ class TestCommandPalette:
             await pilot.pause()
 
             # Verify results are populated
-            results = palette.query_one("#results", ListView)
+            results = palette.query_one(f"#{wid.COMMAND_RESULTS}", ListView)
             assert len(results.children) > 0, "Should have results"
             assert results.highlighted_child is not None, "Should have highlighted child"
 
@@ -357,12 +358,12 @@ class TestCommandPalette:
             palette.on_show()
 
             # Search for a command with keybinding
-            search_input = palette.query_one("#search", Input)
+            search_input = palette.query_one(f"#{wid.COMMAND_SEARCH}", Input)
             search_input.value = "open"
 
             await pilot.pause()
 
-            results_list = palette.query_one("#results", ListView)
+            results_list = palette.query_one(f"#{wid.COMMAND_RESULTS}", ListView)
             # Check that results contain the keybinding
             # This is a simple check - the keybinding should be in the label text
             assert len(results_list.children) > 0
@@ -406,7 +407,7 @@ class TestCommandPalette:
             palette.add_class("visible")
 
             # Set some search text
-            search_input = palette.query_one("#search", Input)
+            search_input = palette.query_one(f"#{wid.COMMAND_SEARCH}", Input)
             search_input.value = "test"
 
             await pilot.pause()

--- a/caspoon/tests/unit/ui/widgets/test_console.py
+++ b/caspoon/tests/unit/ui/widgets/test_console.py
@@ -3,6 +3,7 @@
 import pytest
 from textual.widgets import RichLog
 
+from caspoon.ui import widget_ids as wid
 from caspoon.ui.widgets.console import Console
 
 
@@ -25,7 +26,7 @@ class TestConsole:
             await pilot.app.mount(console)
 
             # Check RichLog widget is present
-            rich_log = console.query_one("#console_log", RichLog)
+            rich_log = console.query_one(f"#{wid.CONSOLE_LOG}", RichLog)
             assert rich_log is not None
 
     @pytest.mark.asyncio
@@ -42,7 +43,7 @@ class TestConsole:
             await pilot.pause()
 
             # Verify message was logged (RichLog should contain it)
-            rich_log = console.query_one("#console_log", RichLog)
+            rich_log = console.query_one(f"#{wid.CONSOLE_LOG}", RichLog)
             assert len(rich_log.lines) > 0
 
     @pytest.mark.asyncio
@@ -59,7 +60,7 @@ class TestConsole:
             await pilot.pause()
 
             # Verify message was logged
-            rich_log = console.query_one("#console_log", RichLog)
+            rich_log = console.query_one(f"#{wid.CONSOLE_LOG}", RichLog)
             assert len(rich_log.lines) > 0
 
     @pytest.mark.asyncio
@@ -76,7 +77,7 @@ class TestConsole:
             await pilot.pause()
 
             # Verify message was logged
-            rich_log = console.query_one("#console_log", RichLog)
+            rich_log = console.query_one(f"#{wid.CONSOLE_LOG}", RichLog)
             assert len(rich_log.lines) > 0
 
     @pytest.mark.asyncio
@@ -93,7 +94,7 @@ class TestConsole:
             await pilot.pause()
 
             # Verify message was logged
-            rich_log = console.query_one("#console_log", RichLog)
+            rich_log = console.query_one(f"#{wid.CONSOLE_LOG}", RichLog)
             assert len(rich_log.lines) > 0
 
     @pytest.mark.asyncio
@@ -110,7 +111,7 @@ class TestConsole:
             await pilot.pause()
 
             # Verify message was logged
-            rich_log = console.query_one("#console_log", RichLog)
+            rich_log = console.query_one(f"#{wid.CONSOLE_LOG}", RichLog)
             assert len(rich_log.lines) > 0
 
     @pytest.mark.asyncio
@@ -128,7 +129,7 @@ class TestConsole:
             console.log("Message 3")
             await pilot.pause()
 
-            rich_log = console.query_one("#console_log", RichLog)
+            rich_log = console.query_one(f"#{wid.CONSOLE_LOG}", RichLog)
             assert len(rich_log.lines) > 0
 
             # Clear console
@@ -156,7 +157,7 @@ class TestConsole:
             await pilot.pause()
 
             # Verify console is empty
-            rich_log = console.query_one("#console_log", RichLog)
+            rich_log = console.query_one(f"#{wid.CONSOLE_LOG}", RichLog)
             assert len(rich_log.lines) == 0
 
     @pytest.mark.asyncio
@@ -175,5 +176,5 @@ class TestConsole:
             await pilot.pause()
 
             # Verify all messages were logged
-            rich_log = console.query_one("#console_log", RichLog)
+            rich_log = console.query_one(f"#{wid.CONSOLE_LOG}", RichLog)
             assert len(rich_log.lines) >= 3

--- a/caspoon/tests/unit/ui/widgets/test_sidebar.py
+++ b/caspoon/tests/unit/ui/widgets/test_sidebar.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from caspoon.ui import widget_ids as wid
 from caspoon.ui.widgets.sidebar import Sidebar
 
 
@@ -13,7 +14,7 @@ class TestSidebar:
         """Test sidebar initializes correctly."""
         sidebar = Sidebar()
         assert sidebar is not None
-        assert sidebar._explorer is not None
+        assert sidebar.explorer is not None
 
     @pytest.mark.asyncio
     async def test_sidebar_compose(self, app_with_state):
@@ -29,10 +30,10 @@ class TestSidebar:
             assert title is not None
             assert "Navigation" in str(title.renderable)
 
-            filter_input = sidebar.query_one("#function_filter")
+            filter_input = sidebar.query_one(f"#{wid.FUNCTION_FILTER}")
             assert filter_input is not None
 
-            explorer = sidebar.query_one("#function_explorer")
+            explorer = sidebar.query_one(f"#{wid.FUNCTION_EXPLORER}")
             assert explorer is not None
 
     @pytest.mark.asyncio
@@ -45,7 +46,7 @@ class TestSidebar:
             await pilot.pause()
 
             # Get filter input
-            filter_input = sidebar.query_one("#function_filter")
+            filter_input = sidebar.query_one(f"#{wid.FUNCTION_FILTER}")
             assert filter_input is not None
 
             # Simulate typing in filter
@@ -53,7 +54,7 @@ class TestSidebar:
             await pilot.pause()
 
             # Explorer should have filter applied
-            assert sidebar._explorer._filter_text == "test"
+            assert sidebar.explorer.current_filter == "test"
 
     @pytest.mark.asyncio
     async def test_filter_input_submit(self, app_with_state):
@@ -65,7 +66,7 @@ class TestSidebar:
             await pilot.pause()
 
             # Get filter input
-            filter_input = sidebar.query_one("#function_filter")
+            filter_input = sidebar.query_one(f"#{wid.FUNCTION_FILTER}")
             filter_input.focus()
             await pilot.pause()
 
@@ -84,5 +85,5 @@ class TestSidebar:
             await pilot.pause()
 
             # Explorer should be present
-            explorer = sidebar.query_one("#function_explorer")
+            explorer = sidebar.query_one(f"#{wid.FUNCTION_EXPLORER}")
             assert explorer is not None


### PR DESCRIPTION
## Summary\n\n- **Widget ID constants in tests**: All hardcoded `\"#widget_id\"` query strings replaced with `f\"#{wid.CONSTANT}\"` imports from `widget_ids` module across 8 test files.\n- **Public properties instead of private access**: Test assertions now use `view.all_strings`, `view.filtered_strings`, `view.total_count`, `view.filtered_count`, `sidebar.explorer`, and `explorer.current_filter` instead of accessing `_strings`, `_filtered`, `_explorer`, `_filter_text`.\n- **Replaced timing dependencies**: `asyncio.sleep()` calls replaced with `wait_for_workers(app, pilot)` for analysis completion, and `pilot.pause(delay)` replaced with bare `pilot.pause()` for message queue draining. Updated `wait_for_workers` helper to also check `app.state.ui_state.is_analyzing` since CaspoonApp uses a custom worker system.\n\nThis is PR 2 of 2 (test-side changes), building on PR #41 (source-side changes).\n\n## Test plan\n\n- [x] Full test suite passes with coverage (926 passed, 19 skipped)\n- [x] All async analysis integration tests pass\n- [x] All command palette tests pass in isolation\n- [ ] Note: 2 command palette filter tests have a pre-existing test isolation issue that manifests only when run without coverage (different collection order). Not introduced by this PR.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"