### PR TITLE
Fix failing CI test: update capabilities count

### DIFF
--- a/caspoon/tests/unit/utils/test_capabilities.py
+++ b/caspoon/tests/unit/utils/test_capabilities.py
@@ -192,10 +192,11 @@ class TestCapabilities:
         """Test that _detect_all populates all expected capabilities."""
         caps = Capabilities()
 
+        assert "radare2" in caps._capabilities
         assert "windows_pe" in caps._capabilities
         assert "capstone" in caps._capabilities
         assert "yara" in caps._capabilities
         assert "advanced_math" in caps._capabilities
         assert "graphs" in caps._capabilities
         assert "reports" in caps._capabilities
-        assert len(caps._capabilities) == 6
+        assert len(caps._capabilities) == 7


### PR DESCRIPTION
## Summary

Fixes the failing 	est_detect_all_populates_all_capabilities test on CI by updating the expected capability count from 6 to 7.

## Root Cause

PR #51 added adare2 as a new capability in capabilities.py:_detect_all(), bringing the total from 6 to 7 capabilities. The test wasn't updated to reflect this change, causing CI failures across Python 3.10, 3.11, and 3.12.

## Changes

- Updated 	est_capabilities.py:201 assertion from == 6 to == 7
- Added assertion for 'radare2' in caps._capabilities to verify the new capability is present

## Testing

✅ Test now passes locally on Windows Python 3.12  
✅ Compatible with the existing radare2 capability detection logic  
✅ No changes to production code, test-only fix

## Notes

- The 	est_update_from_report_with_raw_backend_data test failure was already fixed in commit 43c4d38 of PR #51
- This PR addresses the only remaining CI test failure

Merges into: ix/r2-detection (PR #51)