### PR TITLE
chore: use pyelftools for file/protections; remove file/checksec

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dir:*)",
+      "Bash(python:*)"
+    ]
+  }
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,9 +25,7 @@ This file provides context and conventions for GitHub Copilot when working in th
 
 ### External Tool Integration
 
-- `file` - File type detection
 - `strings` - String extraction (with fallback implementation)
-- `checksec` - Security feature detection
 - `radare2` - Advanced binary analysis and disassembly
 
 *Note*: Caspoon gracefully handles missing external tools with fallback implementations.
@@ -192,7 +190,6 @@ caspoon/
 @pytest.mark.slow           # Tests taking >1 second
 @pytest.mark.golden         # Regression/golden tests
 @pytest.mark.requires_r2    # Requires radare2 installed
-@pytest.mark.requires_checksec  # Requires checksec installed
 @pytest.mark.requires_strings   # Requires strings command
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A modular, defensive binary analysis toolkit for reverse engineers and security 
 
 ### Key Features
 
-- 🔍 **Multi-Backend Analysis**: Integrates file, checksec, strings, and radare2
+- 🔍 **Multi-Backend Analysis**: Integrates pyelftools (ELF parsing), strings, and radare2
 - 🛡️ **Security-First**: Designed for analyzing potentially malicious binaries safely
 - 📊 **Comprehensive Reports**: Extract metadata, protections, strings, imports, exports, and disassembly
 - 🧩 **Modular Architecture**: Easy to extend with new analysis modules
@@ -116,9 +116,7 @@ print(f"Imports: {len(report.imports)}")
 
 Most features work without external tools, but some enhanced analysis requires:
 
-- **file** - File type detection (usually pre-installed on Unix systems)
 - **strings** - String extraction (usually pre-installed)
-- **checksec** - Security features detection (install: `apt install checksec` or from [GitHub](https://github.com/slimm609/checksec.sh))
 - **radare2** - Advanced disassembly and analysis (install: `apt install radare2` or from [radare.org](https://rada.re/))
 
 Caspoon gracefully handles missing tools and provides fallback implementations where possible.
@@ -173,8 +171,8 @@ Each **recon module** enriches the report with its findings. See [docs/reference
 ```bash
 # Example: Find all binaries with full RELRO in a directory
 for bin in /usr/bin/*; do
-  if file "$bin" | grep -q "ELF"; then
-    result=$(caspoon "$bin" 2>/dev/null)
+  result=$(caspoon "$bin" 2>/dev/null || echo "")
+  if echo "$result" | jq -e '.file_type | test("ELF")' >/dev/null 2>&1; then
     if echo "$result" | jq -e '.protections.relro == "full"' >/dev/null 2>&1; then
       echo "$bin: Full RELRO"
     fi
@@ -232,7 +230,7 @@ Caspoon is actively developed and maintained. Current status:
 - ✅ Core analysis pipeline complete
 - ✅ Comprehensive test coverage (84%)
 - ✅ CLI interface functional
-- ✅ Multi-backend integration (file, checksec, strings, radare2)
+- ✅ Multi-backend integration (pyelftools, strings, radare2)
 - 🚧 Additional backends planned (Ghidra, Binary Ninja)
 - 🚧 Advanced visualizations in development
 

--- a/caspoon/core/models.py
+++ b/caspoon/core/models.py
@@ -44,7 +44,7 @@ class ExecutableReport:
         path: Path to the analyzed executable
         arch: Architecture (e.g., x86_64, ARM)
         bits: Bit width (32 or 64), or None if unknown
-        file_type: File type description from 'file' command
+        file_type: File type description
         stripped: Whether debug symbols are stripped
         protections: Security protection information
         strings: List of extracted strings

--- a/caspoon/docs/DEPENDENCIES.md
+++ b/caspoon/docs/DEPENDENCIES.md
@@ -97,7 +97,7 @@ pip install -e ".[dev]"
 ### Optional
 - radare2 (for binary analysis)
 - GCC (for building test fixtures)
-- checksec (for protection detection)
+- checksec (no longer required; protections detected via pyelftools)
 
 ### Installation (Ubuntu/Debian)
 ```bash

--- a/caspoon/docs/guides/TESTING.md
+++ b/caspoon/docs/guides/TESTING.md
@@ -191,7 +191,6 @@ Tests are marked with categories for easy filtering:
 @pytest.mark.slow              # Takes >1 second
 @pytest.mark.golden            # Golden/regression test
 @pytest.mark.requires_r2       # Requires radare2
-@pytest.mark.requires_checksec # Requires checksec tool
 ```
 
 Run tests by marker:
@@ -462,7 +461,7 @@ Be descriptive:
 
 ✅ **Good names:**
 - `test_detects_full_pie_protection`
-- `test_handles_missing_checksec_gracefully`
+- `test_handles_non_elf_file_gracefully`
 - `test_extracts_strings_from_stripped_binary`
 
 ❌ **Avoid:**
@@ -691,8 +690,8 @@ git commit -m "Add golden test for my_binary"
    ```python
    # Good: Focused test
    def test_detects_pie_enabled(self):
-       result = parse_checksec("PIE enabled")
-       assert result.pie == "full"
+       report = run_protections(elf_path)
+       assert report.protections.pie is True
    
    # Avoid: Testing multiple things
    def test_everything(self):
@@ -936,16 +935,16 @@ make clean && make
 pip install -e .
 ```
 
-#### "Tool not available" (checksec, radare2, etc.)
+#### "Tool not available" (radare2, etc.)
 
 Tests should skip gracefully, but if you want full coverage:
 
 ```bash
 # Ubuntu/Debian
-sudo apt install checksec radare2
+sudo apt install radare2
 
 # macOS
-brew install checksec radare2
+brew install radare2
 ```
 
 #### "Coverage doesn't match expected"

--- a/caspoon/docs/guides/TESTING_GUIDE.md
+++ b/caspoon/docs/guides/TESTING_GUIDE.md
@@ -137,7 +137,7 @@ Mark your tests appropriately:
 @pytest.mark.slow          # Slow test (>1s)
 @pytest.mark.golden        # Golden/regression test
 @pytest.mark.requires_r2   # Requires radare2
-@pytest.mark.requires_checksec  # Requires checksec
+
 ```
 
 Run specific markers:

--- a/caspoon/docs/reference/OVERVIEW.md
+++ b/caspoon/docs/reference/OVERVIEW.md
@@ -137,9 +137,9 @@ class SomeRecon:
 
 **Current Modules:**
 
-- **FileInfoRecon** (`recon/file_info.py`): Uses Unix `file` command to extract basic metadata (architecture, bit-width, stripped status)
+- **FileInfoRecon** (`recon/file_info.py`): Uses pyelftools to extract basic metadata (architecture, bit-width, stripped status)
 
-- **ProtectionsRecon** (`recon/protections.py`): Uses `checksec` tool to identify security features (PIE, NX, canary, RELRO)
+- **ProtectionsRecon** (`recon/protections.py`): Uses pyelftools to identify security features (PIE, NX, canary, RELRO)
 
 - **StringsRecon** (`recon/strings_mod.py`): Extracts printable strings from the binary
 
@@ -177,8 +177,6 @@ Defined in `pyproject.toml`:
 - **rich**: Rich text and formatting for terminal output
 
 External tools used via subprocess:
-- **file**: File type identification (standard Unix tool)
-- **checksec**: Security features detection
 - **radare2**: Binary analysis backend (via r2pipe)
 
 ## Usage Patterns
@@ -256,8 +254,8 @@ class ReconRunner:
 - Use dataclasses for data models
 - Follow the recon module interface pattern
 - Store backend-specific data in `raw_backend_data` dictionary
-- Use subprocess for external tool integration
-- Handle missing tools gracefully (e.g., checksec fallback)
+- Use pyelftools for ELF parsing and analysis
+- Handle non-ELF files gracefully
 
 ### Error Handling
 - Recon modules should handle errors internally and return report

--- a/caspoon/pyproject.toml
+++ b/caspoon/pyproject.toml
@@ -104,7 +104,6 @@ markers = [
     "unit: marks tests as unit tests",
     "golden: marks tests as golden/regression tests",
     "requires_r2: marks tests that require radare2",
-    "requires_checksec: marks tests that require checksec tool",
     "requires_strings: marks tests that require strings tool",
 ]
 

--- a/caspoon/recon/file_info.py
+++ b/caspoon/recon/file_info.py
@@ -2,32 +2,31 @@
 
 import logging
 import os
-import subprocess
+
+from elftools.elf.elffile import ELFFile
 
 from ..core.models import ExecutableReport
 
 logger = logging.getLogger(__name__)
 
-# Configuration
-FILE_CMD_TIMEOUT = 10  # Timeout for file command in seconds
-
-# Architecture patterns for detection
-ARCH_PATTERNS: dict[str, str] = {
-    "x86-64": "x86_64",
-    "x86_64": "x86_64",
-    "amd64": "x86_64",
-    "x86": "x86",
-    "i386": "x86",
-    "i686": "x86",
-    "ARM": "ARM",
-    "aarch64": "ARM64",
-    "MIPS": "MIPS",
-    "PowerPC": "PowerPC",
+# Architecture mapping from ELF e_machine values to human-readable names
+ARCH_MAP: dict[int, str] = {
+    0x3E: "x86_64",      # EM_X86_64
+    0x03: "x86",         # EM_386
+    0x28: "ARM",         # EM_ARM
+    0xB7: "ARM64",       # EM_AARCH64
+    0x08: "MIPS",        # EM_MIPS
+    0x14: "PowerPC",     # EM_PPC
+    0x15: "PowerPC64",   # EM_PPC64
+    0xF3: "RISC-V",      # EM_RISCV
+    0x16: "S390",        # EM_S390
+    0x2A: "SuperH",      # EM_SH
+    0x32: "IA-64",       # EM_IA_64
 }
 
 
 class FileInfoRecon:
-    """Extracts basic file information using the 'file' command.
+    """Extracts basic file information using pyelftools.
 
     Analyzes the executable to determine architecture, bit width,
     file type, and whether debug symbols are stripped.
@@ -56,61 +55,47 @@ class FileInfoRecon:
             return report
 
         try:
-            result = subprocess.run(
-                ["file", path],
-                capture_output=True,
-                text=True,
-                timeout=FILE_CMD_TIMEOUT,
-            )
+            with open(path, "rb") as f:
+                try:
+                    elffile = ELFFile(f)
+                except Exception as e:
+                    logger.warning(f"Not an ELF file or invalid ELF: {path} - {e}")
+                    report.file_type = "Not an ELF file"
+                    return report
 
-            if result.returncode != 0:
-                logger.error(f"'file' command failed with return code {result.returncode}")
-                report.file_type = "Error: file command failed"
-                return report
+                # Detect architecture
+                e_machine = elffile.header["e_machine"]
+                report.arch = ARCH_MAP.get(e_machine, "Unknown")
 
-            output = result.stdout.strip()
-            report.file_type = output
+                # Detect bit width
+                elfclass = elffile.elfclass
+                report.bits = 64 if elfclass == 64 else 32 if elfclass == 32 else None
 
-            # Detect architecture more robustly
-            report.arch = self._detect_architecture(output)
+                # Detect endianness
+                endian_str = "LSB" if elffile.little_endian else "MSB"
 
-            # Detect bit width
-            if "64-bit" in output:
-                report.bits = 64
-            elif "32-bit" in output:
-                report.bits = 32
-            else:
-                report.bits = None  # Unknown bit width
+                # Detect file type
+                e_type = elffile.header["e_type"]
+                if e_type == "ET_EXEC":
+                    type_str = "executable"
+                elif e_type == "ET_DYN":
+                    type_str = "shared object"
+                elif e_type == "ET_REL":
+                    type_str = "relocatable"
+                elif e_type == "ET_CORE":
+                    type_str = "core dump"
+                else:
+                    type_str = "unknown type"
 
-            # Check if stripped
-            report.stripped = "not stripped" not in output.lower()
+                # Build descriptive file_type string
+                arch_str = report.arch if report.arch != "Unknown" else f"machine {e_machine}"
+                report.file_type = f"ELF {report.bits}-bit {endian_str} {type_str}, {arch_str}"
 
-        except FileNotFoundError:
-            logger.error("'file' command not found. Please install it.")
-            report.file_type = "Error: 'file' command not available"
-        except subprocess.TimeoutExpired:
-            logger.error(f"'file' command timed out on {path}")
-            report.file_type = "Error: Timeout"
+                # Check if stripped (no symbol table)
+                report.stripped = elffile.get_section_by_name(".symtab") is None
+
         except Exception as e:
             logger.error(f"Unexpected error in FileInfoRecon: {e}")
             report.file_type = f"Error: {str(e)}"
 
         return report
-
-    def _detect_architecture(self, file_output: str) -> str:
-        """Detect architecture from file command output.
-
-        Args:
-            file_output: Output from the 'file' command
-
-        Returns:
-            Detected architecture name or "Unknown"
-        """
-        file_lower = file_output.lower()
-
-        for pattern, arch in ARCH_PATTERNS.items():
-            if pattern.lower() in file_lower:
-                return arch
-
-        logger.warning(f"Could not detect architecture from: {file_output}")
-        return "Unknown"

--- a/caspoon/recon/file_info.py
+++ b/caspoon/recon/file_info.py
@@ -9,19 +9,19 @@ from ..core.models import ExecutableReport
 
 logger = logging.getLogger(__name__)
 
-# Architecture mapping from ELF e_machine values to human-readable names
-ARCH_MAP: dict[int, str] = {
-    0x3E: "x86_64",      # EM_X86_64
-    0x03: "x86",         # EM_386
-    0x28: "ARM",         # EM_ARM
-    0xB7: "ARM64",       # EM_AARCH64
-    0x08: "MIPS",        # EM_MIPS
-    0x14: "PowerPC",     # EM_PPC
-    0x15: "PowerPC64",   # EM_PPC64
-    0xF3: "RISC-V",      # EM_RISCV
-    0x16: "S390",        # EM_S390
-    0x2A: "SuperH",      # EM_SH
-    0x32: "IA-64",       # EM_IA_64
+# Architecture mapping from ELF e_machine string values (as returned by pyelftools) to human-readable names
+ARCH_MAP: dict[str, str] = {
+    "EM_X86_64": "x86_64",
+    "EM_386": "x86",
+    "EM_ARM": "ARM",
+    "EM_AARCH64": "ARM64",
+    "EM_MIPS": "MIPS",
+    "EM_PPC": "PowerPC",
+    "EM_PPC64": "PowerPC64",
+    "EM_RISCV": "RISC-V",
+    "EM_S390": "S390",
+    "EM_SH": "SuperH",
+    "EM_IA_64": "IA-64",
 }
 
 

--- a/caspoon/recon/protections.py
+++ b/caspoon/recon/protections.py
@@ -1,18 +1,18 @@
 """Security protections reconnaissance module."""
 
 import logging
-import subprocess
+
+from elftools.elf.constants import P_FLAGS
+from elftools.elf.dynamic import DynamicSection
+from elftools.elf.elffile import ELFFile
 
 from ..core.models import ExecutableReport, ProtectionInfo
 
 logger = logging.getLogger(__name__)
 
-# Configuration
-CHECKSEC_TIMEOUT = 10  # Timeout for checksec command in seconds
-
 
 class ProtectionsRecon:
-    """Analyzes security protections using the 'checksec' tool.
+    """Analyzes security protections using pyelftools.
 
     Detects security features including PIE, NX, stack canary, and RELRO.
     """
@@ -29,49 +29,106 @@ class ProtectionsRecon:
         Returns:
             Updated ExecutableReport with protection information
         """
-        try:
-            result = subprocess.run(
-                ["checksec", f"--file={path}"],
-                capture_output=True,
-                text=True,
-                timeout=CHECKSEC_TIMEOUT,
-            )
-
-            if result.returncode != 0:
-                logger.warning(
-                    f"checksec returned non-zero exit code {result.returncode}. "
-                    f"stderr: {result.stderr.strip() if result.stderr else 'none'}"
-                )
-                report.protections = ProtectionInfo(relro="checksec_error")
-                return report
-
-            output = result.stdout
-
-        except FileNotFoundError:
-            logger.warning("'checksec' command not found. Protection detection unavailable.")
-            report.protections = ProtectionInfo(relro="checksec_not_found")
-            return report
-        except subprocess.TimeoutExpired:
-            logger.error(f"'checksec' command timed out on {path}")
-            report.protections = ProtectionInfo(relro="checksec_timeout")
-            return report
-        except Exception as e:
-            logger.error(f"Unexpected error in ProtectionsRecon: {e}")
-            report.protections = ProtectionInfo(relro=f"error: {str(e)}")
-            return report
-
         pi = ProtectionInfo()
 
-        pi.pie = "PIE enabled" in output
-        pi.nx = "NX enabled" in output
-        pi.canary = "Canary found" in output
+        try:
+            with open(path, "rb") as f:
+                try:
+                    elffile = ELFFile(f)
+                except Exception as e:
+                    logger.warning(f"Not an ELF file or invalid ELF: {path} - {e}")
+                    pi.relro = "not_elf"
+                    report.protections = pi
+                    return report
 
-        if "Full RELRO" in output:
-            pi.relro = "full"
-        elif "Partial RELRO" in output:
-            pi.relro = "partial"
-        else:
-            pi.relro = "none"
+                # Detect PIE: ET_DYN type indicates position independent
+                pi.pie = elffile.header["e_type"] == "ET_DYN"
+
+                # Detect NX: Check PT_GNU_STACK segment for execute permission
+                pi.nx = self._check_nx(elffile)
+
+                # Detect Stack Canary: Look for __stack_chk_fail symbol
+                pi.canary = self._check_canary(elffile)
+
+                # Detect RELRO: Check for PT_GNU_RELRO segment and DT_BIND_NOW
+                pi.relro = self._check_relro(elffile)
+
+        except Exception as e:
+            logger.error(f"Unexpected error in ProtectionsRecon: {e}")
+            pi.relro = f"error: {str(e)}"
 
         report.protections = pi
         return report
+
+    def _check_nx(self, elffile: ELFFile) -> bool:
+        """Check if NX (No-Execute) protection is enabled.
+
+        Args:
+            elffile: Parsed ELF file
+
+        Returns:
+            True if NX is enabled, False otherwise
+        """
+        # Look for PT_GNU_STACK segment
+        for segment in elffile.iter_segments():
+            if segment["p_type"] == "PT_GNU_STACK":
+                # Check if executable flag is NOT set
+                flags = segment["p_flags"]
+                return not (flags & P_FLAGS.PF_X)
+
+        # If no PT_GNU_STACK segment found, NX is enabled by default on modern systems
+        return True
+
+    def _check_canary(self, elffile: ELFFile) -> bool:
+        """Check if stack canary protection is enabled.
+
+        Args:
+            elffile: Parsed ELF file
+
+        Returns:
+            True if stack canary is present, False otherwise
+        """
+        # Check dynamic symbol table for __stack_chk_fail
+        dynsym = elffile.get_section_by_name(".dynsym")
+        if dynsym:
+            for symbol in dynsym.iter_symbols():
+                if symbol.name == "__stack_chk_fail":
+                    return True
+
+        return False
+
+    def _check_relro(self, elffile: ELFFile) -> str:
+        """Check RELRO (Relocation Read-Only) protection level.
+
+        Args:
+            elffile: Parsed ELF file
+
+        Returns:
+            "full", "partial", or "none"
+        """
+        has_gnu_relro = False
+        has_bind_now = False
+
+        # Check for PT_GNU_RELRO segment
+        for segment in elffile.iter_segments():
+            if segment["p_type"] == "PT_GNU_RELRO":
+                has_gnu_relro = True
+                break
+
+        # Check for DT_BIND_NOW in .dynamic section
+        for section in elffile.iter_sections():
+            if isinstance(section, DynamicSection):
+                for tag in section.iter_tags():
+                    if tag.entry.d_tag == "DT_BIND_NOW":
+                        has_bind_now = True
+                        break
+                if has_bind_now:
+                    break
+
+        # Determine RELRO level
+        if has_gnu_relro and has_bind_now:
+            return "full"
+        elif has_gnu_relro:
+            return "partial"
+        else:
+            return "none"

--- a/caspoon/recon/protections.py
+++ b/caspoon/recon/protections.py
@@ -115,11 +115,15 @@ class ProtectionsRecon:
                 has_gnu_relro = True
                 break
 
-        # Check for DT_BIND_NOW in .dynamic section
+        # Check for DT_BIND_NOW or DT_FLAGS with DF_BIND_NOW bit in .dynamic section
+        DF_BIND_NOW = 0x8
         for section in elffile.iter_sections():
             if isinstance(section, DynamicSection):
                 for tag in section.iter_tags():
                     if tag.entry.d_tag == "DT_BIND_NOW":
+                        has_bind_now = True
+                        break
+                    if tag.entry.d_tag == "DT_FLAGS" and (tag.entry.d_val & DF_BIND_NOW):
                         has_bind_now = True
                         break
                 if has_bind_now:

--- a/caspoon/tests/README.md
+++ b/caspoon/tests/README.md
@@ -180,7 +180,6 @@ Use markers to categorize tests:
 @pytest.mark.slow              # Slow test (>1s)
 @pytest.mark.golden            # Golden/regression test
 @pytest.mark.requires_r2       # Requires radare2
-@pytest.mark.requires_checksec # Requires checksec tool
 ```
 
 Run by marker:
@@ -265,9 +264,7 @@ make
 
 ### Tool Dependencies
 Some tests require external tools:
-- `file` - File type detection (usually pre-installed)
 - `strings` - String extraction (usually pre-installed)
-- `checksec` - Security feature detection (optional, tests skip if missing)
 - `radare2` - Advanced analysis (optional, tests skip if missing)
 
 Tests gracefully skip if tools are missing.

--- a/caspoon/tests/integration/test_pipeline.py
+++ b/caspoon/tests/integration/test_pipeline.py
@@ -89,8 +89,8 @@ class TestFullPipeline:
             report.stripped == expected_stripped
         ), f"Stripped status should be {expected_stripped} for {binary_name}"
 
-        # Verify PIE (if protections were detected and checksec is available)
-        if report.protections and report.protections.relro != "checksec_not_found":
+        # Verify PIE (if protections were detected)
+        if report.protections and report.protections.relro not in ("not_elf", "Unknown"):
             assert (
                 report.protections.pie == expected_pie
             ), f"PIE should be {expected_pie} for {binary_name}"

--- a/caspoon/tests/unit/recon/test_file_info.py
+++ b/caspoon/tests/unit/recon/test_file_info.py
@@ -79,7 +79,7 @@ class TestFileInfoRecon:
         test_file.write_bytes(b"test")
 
         mock_elffile = MagicMock()
-        mock_elffile.header = {"e_machine": 0x3E, "e_type": "ET_EXEC"}  # x86_64, executable
+        mock_elffile.header = {"e_machine": "EM_X86_64", "e_type": "ET_EXEC"}  # x86_64, executable
         mock_elffile.elfclass = 64
         mock_elffile.little_endian = True
         mock_elffile.get_section_by_name.return_value = Mock()  # not stripped
@@ -98,7 +98,7 @@ class TestFileInfoRecon:
         test_file.write_bytes(b"test")
 
         mock_elffile = MagicMock()
-        mock_elffile.header = {"e_machine": 0x03, "e_type": "ET_EXEC"}  # x86, executable
+        mock_elffile.header = {"e_machine": "EM_386", "e_type": "ET_EXEC"}  # x86, executable
         mock_elffile.elfclass = 32
         mock_elffile.little_endian = True
         mock_elffile.get_section_by_name.return_value = Mock()  # not stripped
@@ -117,10 +117,9 @@ class TestFileInfoRecon:
         test_file.write_bytes(b"test")
 
         mock_elffile = MagicMock()
-        mock_elffile.header = {"e_machine": 0x3E, "e_type": "ET_EXEC"}
+        mock_elffile.header = {"e_machine": "EM_X86_64", "e_type": "ET_EXEC"}
         mock_elffile.elfclass = 0  # Unknown
         mock_elffile.little_endian = True
-        mock_elffile.get_section_by_name.return_value = None
 
         with patch("builtins.open", mock_open(read_data=b"fake elf")):
             with patch("caspoon.recon.file_info.ELFFile", return_value=mock_elffile):
@@ -135,7 +134,7 @@ class TestFileInfoRecon:
         test_file.write_bytes(b"test")
 
         mock_elffile = MagicMock()
-        mock_elffile.header = {"e_machine": 0x3E, "e_type": "ET_EXEC"}
+        mock_elffile.header = {"e_machine": "EM_X86_64", "e_type": "ET_EXEC"}
         mock_elffile.elfclass = 64
         mock_elffile.little_endian = True
         mock_elffile.get_section_by_name.return_value = None  # No .symtab = stripped
@@ -153,7 +152,7 @@ class TestFileInfoRecon:
         test_file.write_bytes(b"test")
 
         mock_elffile = MagicMock()
-        mock_elffile.header = {"e_machine": 0x3E, "e_type": "ET_EXEC"}
+        mock_elffile.header = {"e_machine": "EM_X86_64", "e_type": "ET_EXEC"}
         mock_elffile.elfclass = 64
         mock_elffile.little_endian = True
         mock_elffile.get_section_by_name.return_value = Mock()  # .symtab exists = not stripped
@@ -191,15 +190,15 @@ class TestFileInfoRecon:
     @pytest.mark.parametrize(
         "e_machine,expected_arch",
         [
-            (0x3E, "x86_64"),      # EM_X86_64
-            (0x03, "x86"),         # EM_386
-            (0x28, "ARM"),         # EM_ARM
-            (0xB7, "ARM64"),       # EM_AARCH64
-            (0x08, "MIPS"),        # EM_MIPS
-            (0x14, "PowerPC"),     # EM_PPC
-            (0x15, "PowerPC64"),   # EM_PPC64
-            (0xF3, "RISC-V"),      # EM_RISCV
-            (0x9999, "Unknown"),   # Unknown architecture
+            ("EM_X86_64", "x86_64"),
+            ("EM_386", "x86"),
+            ("EM_ARM", "ARM"),
+            ("EM_AARCH64", "ARM64"),
+            ("EM_MIPS", "MIPS"),
+            ("EM_PPC", "PowerPC"),
+            ("EM_PPC64", "PowerPC64"),
+            ("EM_RISCV", "RISC-V"),
+            ("EM_UNKNOWN_9999", "Unknown"),   # Unknown architecture
         ],
     )
     def test_architecture_detection(self, recon, tmp_path, e_machine, expected_arch):

--- a/caspoon/tests/unit/recon/test_file_info.py
+++ b/caspoon/tests/unit/recon/test_file_info.py
@@ -4,14 +4,13 @@ Tests the FileInfoRecon recon module which extracts basic file information
 including architecture, bit width, file type, and stripped status.
 """
 
-import subprocess
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import pytest
 
 from caspoon.core.models import ExecutableReport
-from caspoon.recon.file_info import ARCH_PATTERNS, FileInfoRecon
+from caspoon.recon.file_info import ARCH_MAP, FileInfoRecon
 
 
 class TestFileInfoRecon:
@@ -79,142 +78,147 @@ class TestFileInfoRecon:
         test_file = tmp_path / "test_binary"
         test_file.write_bytes(b"test")
 
-        mock_output = f"{test_file}: ELF 64-bit LSB executable, x86-64, version 1"
+        mock_elffile = MagicMock()
+        mock_elffile.header = {"e_machine": 0x3E, "e_type": "ET_EXEC"}  # x86_64, executable
+        mock_elffile.elfclass = 64
+        mock_elffile.little_endian = True
+        mock_elffile.get_section_by_name.return_value = Mock()  # not stripped
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = Mock(returncode=0, stdout=mock_output)
+        with patch("builtins.open", mock_open(read_data=b"fake elf")):
+            with patch("caspoon.recon.file_info.ELFFile", return_value=mock_elffile):
+                report = ExecutableReport(path=str(test_file))
+                result = recon.run(str(test_file), report)
 
-            report = ExecutableReport(path=str(test_file))
-            result = recon.run(str(test_file), report)
-
-            assert result.bits == 64
-            assert result.arch == "x86_64"
+                assert result.bits == 64
+                assert result.arch == "x86_64"
 
     def test_32bit_detection(self, recon, tmp_path):
         """Test detection of 32-bit binary."""
         test_file = tmp_path / "test_binary"
         test_file.write_bytes(b"test")
 
-        mock_output = f"{test_file}: ELF 32-bit LSB executable, i386, version 1"
+        mock_elffile = MagicMock()
+        mock_elffile.header = {"e_machine": 0x03, "e_type": "ET_EXEC"}  # x86, executable
+        mock_elffile.elfclass = 32
+        mock_elffile.little_endian = True
+        mock_elffile.get_section_by_name.return_value = Mock()  # not stripped
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = Mock(returncode=0, stdout=mock_output)
+        with patch("builtins.open", mock_open(read_data=b"fake elf")):
+            with patch("caspoon.recon.file_info.ELFFile", return_value=mock_elffile):
+                report = ExecutableReport(path=str(test_file))
+                result = recon.run(str(test_file), report)
 
-            report = ExecutableReport(path=str(test_file))
-            result = recon.run(str(test_file), report)
+                assert result.bits == 32
+                assert result.arch == "x86"
 
-            assert result.bits == 32
-            assert result.arch == "x86"
-
-    def test_unknown_bit_width(self, recon):
+    def test_unknown_bit_width(self, recon, tmp_path):
         """Test handling of unknown bit width."""
-        mock_output = "/test/binary: data"
+        test_file = tmp_path / "test_binary"
+        test_file.write_bytes(b"test")
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = Mock(returncode=0, stdout=mock_output)
+        mock_elffile = MagicMock()
+        mock_elffile.header = {"e_machine": 0x3E, "e_type": "ET_EXEC"}
+        mock_elffile.elfclass = 0  # Unknown
+        mock_elffile.little_endian = True
+        mock_elffile.get_section_by_name.return_value = None
 
-            report = ExecutableReport(path="/test/binary")
-            result = recon.run("/test/binary", report)
+        with patch("builtins.open", mock_open(read_data=b"fake elf")):
+            with patch("caspoon.recon.file_info.ELFFile", return_value=mock_elffile):
+                report = ExecutableReport(path=str(test_file))
+                result = recon.run(str(test_file), report)
 
-            assert result.bits is None
+                assert result.bits is None
 
     def test_stripped_detection(self, recon, tmp_path):
         """Test detection of stripped binary."""
         test_file = tmp_path / "test_binary"
         test_file.write_bytes(b"test")
 
-        mock_output = f"{test_file}: ELF 64-bit LSB executable, x86-64, stripped"
+        mock_elffile = MagicMock()
+        mock_elffile.header = {"e_machine": 0x3E, "e_type": "ET_EXEC"}
+        mock_elffile.elfclass = 64
+        mock_elffile.little_endian = True
+        mock_elffile.get_section_by_name.return_value = None  # No .symtab = stripped
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = Mock(returncode=0, stdout=mock_output)
+        with patch("builtins.open", mock_open(read_data=b"fake elf")):
+            with patch("caspoon.recon.file_info.ELFFile", return_value=mock_elffile):
+                report = ExecutableReport(path=str(test_file))
+                result = recon.run(str(test_file), report)
 
-            report = ExecutableReport(path=str(test_file))
-            result = recon.run(str(test_file), report)
-
-            assert result.stripped is True
+                assert result.stripped is True
 
     def test_not_stripped_detection(self, recon, tmp_path):
         """Test detection of non-stripped binary."""
         test_file = tmp_path / "test_binary"
         test_file.write_bytes(b"test")
 
-        mock_output = f"{test_file}: ELF 64-bit LSB executable, x86-64, not stripped"
+        mock_elffile = MagicMock()
+        mock_elffile.header = {"e_machine": 0x3E, "e_type": "ET_EXEC"}
+        mock_elffile.elfclass = 64
+        mock_elffile.little_endian = True
+        mock_elffile.get_section_by_name.return_value = Mock()  # .symtab exists = not stripped
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = Mock(returncode=0, stdout=mock_output)
+        with patch("builtins.open", mock_open(read_data=b"fake elf")):
+            with patch("caspoon.recon.file_info.ELFFile", return_value=mock_elffile):
+                report = ExecutableReport(path=str(test_file))
+                result = recon.run(str(test_file), report)
 
-            report = ExecutableReport(path=str(test_file))
-            result = recon.run(str(test_file), report)
+                assert result.stripped is False
 
-            assert result.stripped is False
-
-    def test_file_command_not_found(self, recon, tmp_path):
-        """Test handling when 'file' command is not available."""
+    def test_non_elf_file(self, recon, tmp_path):
+        """Test handling when file is not an ELF file."""
         test_file = tmp_path / "test_binary"
-        test_file.write_text("test")
+        test_file.write_text("not an elf file")
 
-        with patch("subprocess.run", side_effect=FileNotFoundError):
-            report = ExecutableReport(path=str(test_file))
-            result = recon.run(str(test_file), report)
+        with patch("builtins.open", mock_open(read_data=b"not elf")):
+            with patch("caspoon.recon.file_info.ELFFile", side_effect=Exception("Not ELF")):
+                report = ExecutableReport(path=str(test_file))
+                result = recon.run(str(test_file), report)
 
-            assert "Error: 'file' command not available" in result.file_type
-
-    def test_file_command_timeout(self, recon, tmp_path):
-        """Test handling when 'file' command times out."""
-        test_file = tmp_path / "test_binary"
-        test_file.write_text("test")
-
-        import subprocess
-
-        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("file", 10)):
-            report = ExecutableReport(path=str(test_file))
-            result = recon.run(str(test_file), report)
-
-            assert "Error: Timeout" in result.file_type
-
-    def test_file_command_nonzero_return(self, recon, tmp_path):
-        """Test handling when 'file' command fails."""
-        test_file = tmp_path / "test_binary"
-        test_file.write_text("test")
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = Mock(returncode=1, stdout="")
-
-            report = ExecutableReport(path=str(test_file))
-            result = recon.run(str(test_file), report)
-
-            assert "Error: file command failed" in result.file_type
+                assert "Not an ELF file" in result.file_type
 
     def test_unexpected_error(self, recon, tmp_path):
         """Test handling of unexpected exception."""
         test_file = tmp_path / "test_binary"
         test_file.write_text("test")
 
-        with patch("subprocess.run", side_effect=RuntimeError("Unexpected")):
+        with patch("builtins.open", side_effect=RuntimeError("Unexpected")):
             report = ExecutableReport(path=str(test_file))
             result = recon.run(str(test_file), report)
 
             assert "Error:" in result.file_type
 
     @pytest.mark.parametrize(
-        "arch_string,expected_arch",
+        "e_machine,expected_arch",
         [
-            ("x86-64", "x86_64"),
-            ("x86_64", "x86_64"),
-            ("amd64", "x86_64"),
-            ("i386", "x86"),
-            ("i686", "x86"),
-            ("ARM", "ARM"),
-            ("aarch64", "ARM64"),
-            ("MIPS", "MIPS"),
-            ("PowerPC", "PowerPC"),
-            ("unknown architecture", "Unknown"),
+            (0x3E, "x86_64"),      # EM_X86_64
+            (0x03, "x86"),         # EM_386
+            (0x28, "ARM"),         # EM_ARM
+            (0xB7, "ARM64"),       # EM_AARCH64
+            (0x08, "MIPS"),        # EM_MIPS
+            (0x14, "PowerPC"),     # EM_PPC
+            (0x15, "PowerPC64"),   # EM_PPC64
+            (0xF3, "RISC-V"),      # EM_RISCV
+            (0x9999, "Unknown"),   # Unknown architecture
         ],
     )
-    def test_architecture_detection(self, recon, arch_string, expected_arch):
+    def test_architecture_detection(self, recon, tmp_path, e_machine, expected_arch):
         """Test architecture detection for various architectures."""
-        result = recon._detect_architecture(f"ELF 64-bit LSB executable, {arch_string}")
-        assert result == expected_arch
+        test_file = tmp_path / "test_binary"
+        test_file.write_bytes(b"test")
+
+        mock_elffile = MagicMock()
+        mock_elffile.header = {"e_machine": e_machine, "e_type": "ET_EXEC"}
+        mock_elffile.elfclass = 64
+        mock_elffile.little_endian = True
+        mock_elffile.get_section_by_name.return_value = None
+
+        with patch("builtins.open", mock_open(read_data=b"fake elf")):
+            with patch("caspoon.recon.file_info.ELFFile", return_value=mock_elffile):
+                report = ExecutableReport(path=str(test_file))
+                result = recon.run(str(test_file), report)
+
+                assert result.arch == expected_arch
 
     @pytest.mark.integration
     def test_real_test_binary_x64(self, recon, test_binaries_dir):

--- a/caspoon/tests/unit/recon/test_protections.py
+++ b/caspoon/tests/unit/recon/test_protections.py
@@ -1,6 +1,6 @@
 """Unit tests for ProtectionsRecon module."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import pytest
 
@@ -22,143 +22,152 @@ class TestProtectionsRecon:
 
     def test_full_protections_detection(self, recon):
         """Test detection of all protections enabled."""
-        mock_output = """
-RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH
-Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH
-"""
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = Mock(returncode=0, stdout=mock_output)
+        mock_elffile = MagicMock()
+        mock_elffile.header = {"e_type": "ET_DYN"}  # PIE enabled
 
-            report = ExecutableReport(path="/test/binary")
-            result = recon.run("/test/binary", report)
+        # Mock PT_GNU_STACK segment with NX (no execute flag)
+        mock_stack_segment = Mock()
+        mock_stack_segment.__getitem__ = lambda self, key: {
+            "p_type": "PT_GNU_STACK",
+            "p_flags": 0x6,  # RW, no execute (PF_X = 0x1)
+        }[key]
 
-            assert result.protections.pie is True
-            assert result.protections.nx is True
-            assert result.protections.canary is True
-            assert result.protections.relro == "full"
+        # Mock PT_GNU_RELRO segment
+        mock_relro_segment = Mock()
+        mock_relro_segment.__getitem__ = lambda self, key: {
+            "p_type": "PT_GNU_RELRO",
+            "p_flags": 0x4,
+        }[key]
+
+        mock_elffile.iter_segments.return_value = [mock_stack_segment, mock_relro_segment]
+
+        # Mock .dynsym section with __stack_chk_fail
+        mock_symbol = Mock()
+        mock_symbol.name = "__stack_chk_fail"
+        mock_dynsym = Mock()
+        mock_dynsym.iter_symbols.return_value = [mock_symbol]
+        
+        # Mock .dynamic section with DT_BIND_NOW
+        mock_bind_tag = Mock()
+        mock_bind_tag.entry.d_tag = "DT_BIND_NOW"
+        mock_dynamic = Mock()
+        mock_dynamic.iter_tags.return_value = [mock_bind_tag]
+
+        def mock_get_section(name):
+            if name == ".dynsym":
+                return mock_dynsym
+            return None
+
+        mock_elffile.get_section_by_name = mock_get_section
+        
+        # Mock iter_sections to return dynamic section
+        from elftools.elf.dynamic import DynamicSection
+        mock_dynamic.__class__ = DynamicSection
+        mock_elffile.iter_sections.return_value = [mock_dynamic]
+
+        with patch("builtins.open", mock_open(read_data=b"fake elf")):
+            with patch("caspoon.recon.protections.ELFFile", return_value=mock_elffile):
+                report = ExecutableReport(path="/test/binary")
+                result = recon.run("/test/binary", report)
+
+                assert result.protections.pie is True
+                assert result.protections.nx is True
+                assert result.protections.canary is True
+                assert result.protections.relro == "full"
 
     def test_partial_protections_detection(self, recon):
         """Test detection of partial protections."""
-        mock_output = """
-RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH
-Partial RELRO   No canary found   NX enabled    No PIE          No RPATH   No RUNPATH
-"""
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = Mock(returncode=0, stdout=mock_output)
+        mock_elffile = MagicMock()
+        mock_elffile.header = {"e_type": "ET_EXEC"}  # No PIE
 
-            report = ExecutableReport(path="/test/binary")
-            result = recon.run("/test/binary", report)
+        # Mock PT_GNU_STACK segment with NX
+        mock_stack_segment = Mock()
+        mock_stack_segment.__getitem__ = lambda self, key: {
+            "p_type": "PT_GNU_STACK",
+            "p_flags": 0x6,  # RW, no execute
+        }[key]
 
-            assert result.protections.pie is False
-            assert result.protections.nx is True
-            assert result.protections.canary is False
-            assert result.protections.relro == "partial"
+        # Mock PT_GNU_RELRO segment (partial RELRO)
+        mock_relro_segment = Mock()
+        mock_relro_segment.__getitem__ = lambda self, key: {
+            "p_type": "PT_GNU_RELRO",
+            "p_flags": 0x4,
+        }[key]
+
+        mock_elffile.iter_segments.return_value = [mock_stack_segment, mock_relro_segment]
+
+        # Mock .dynsym section without __stack_chk_fail
+        mock_symbol = Mock()
+        mock_symbol.name = "some_other_symbol"
+        mock_dynsym = Mock()
+        mock_dynsym.iter_symbols.return_value = [mock_symbol]
+
+        mock_elffile.get_section_by_name.return_value = mock_dynsym
+
+        # No DT_BIND_NOW in .dynamic
+        mock_elffile.iter_sections.return_value = []
+
+        with patch("builtins.open", mock_open(read_data=b"fake elf")):
+            with patch("caspoon.recon.protections.ELFFile", return_value=mock_elffile):
+                report = ExecutableReport(path="/test/binary")
+                result = recon.run("/test/binary", report)
+
+                assert result.protections.pie is False
+                assert result.protections.nx is True
+                assert result.protections.canary is False
+                assert result.protections.relro == "partial"
 
     def test_no_protections_detection(self, recon):
         """Test detection of no protections."""
-        mock_output = """
-RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH
-No RELRO        No canary found   NX disabled   No PIE          No RPATH   No RUNPATH
-"""
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = Mock(returncode=0, stdout=mock_output)
+        mock_elffile = MagicMock()
+        mock_elffile.header = {"e_type": "ET_EXEC"}  # No PIE
 
-            report = ExecutableReport(path="/test/binary")
-            result = recon.run("/test/binary", report)
+        # Mock PT_GNU_STACK segment with execute flag (no NX)
+        mock_stack_segment = Mock()
+        mock_stack_segment.__getitem__ = lambda self, key: {
+            "p_type": "PT_GNU_STACK",
+            "p_flags": 0x7,  # RWX (PF_X = 0x1 is set)
+        }[key]
 
-            assert result.protections.pie is False
-            assert result.protections.nx is False
-            assert result.protections.canary is False
-            assert result.protections.relro == "none"
+        mock_elffile.iter_segments.return_value = [mock_stack_segment]
 
-    def test_checksec_not_found(self, recon):
-        """Test handling when checksec is not installed."""
-        with patch("subprocess.run", side_effect=FileNotFoundError):
-            report = ExecutableReport(path="/test/binary")
-            result = recon.run("/test/binary", report)
+        # No .dynsym section
+        mock_elffile.get_section_by_name.return_value = None
 
-            assert result.protections is not None
-            assert result.protections.relro == "checksec_not_found"
-            assert result.protections.pie is False
-            assert result.protections.nx is False
-            assert result.protections.canary is False
+        # No .dynamic sections
+        mock_elffile.iter_sections.return_value = []
 
-    def test_checksec_timeout(self, recon):
-        """Test handling when checksec times out."""
-        import subprocess
+        with patch("builtins.open", mock_open(read_data=b"fake elf")):
+            with patch("caspoon.recon.protections.ELFFile", return_value=mock_elffile):
+                report = ExecutableReport(path="/test/binary")
+                result = recon.run("/test/binary", report)
 
-        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("checksec", 10)):
-            report = ExecutableReport(path="/test/binary")
-            result = recon.run("/test/binary", report)
+                assert result.protections.pie is False
+                assert result.protections.nx is False
+                assert result.protections.canary is False
+                assert result.protections.relro == "none"
 
-            assert result.protections is not None
-            assert result.protections.relro == "checksec_timeout"
+    def test_non_elf_file(self, recon):
+        """Test handling when file is not an ELF file."""
+        with patch("builtins.open", mock_open(read_data=b"not elf")):
+            with patch("caspoon.recon.protections.ELFFile", side_effect=Exception("Not ELF")):
+                report = ExecutableReport(path="/test/binary")
+                result = recon.run("/test/binary", report)
 
-    def test_checksec_non_zero_return(self, recon):
-        """Test handling when checksec returns non-zero exit code."""
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = Mock(returncode=1, stdout="Error")
-
-            report = ExecutableReport(path="/test/binary")
-            result = recon.run("/test/binary", report)
-
-            assert result.protections is not None
-            assert result.protections.relro == "checksec_error"
+                assert result.protections is not None
+                assert result.protections.relro == "not_elf"
+                assert result.protections.pie is False
+                assert result.protections.nx is False
+                assert result.protections.canary is False
 
     def test_unexpected_error_handling(self, recon):
         """Test handling of unexpected exceptions."""
-        with patch("subprocess.run", side_effect=RuntimeError("Unexpected error")):
+        with patch("builtins.open", side_effect=RuntimeError("Unexpected error")):
             report = ExecutableReport(path="/test/binary")
             result = recon.run("/test/binary", report)
 
             assert result.protections is not None
             assert "error:" in result.protections.relro.lower()
-
-    def test_checksec_command_format(self, recon):
-        """Test that checksec is called with correct argument format.
-
-        checksec requires --file=<path> not --file <path> as separate arguments.
-        This test verifies the command is properly formatted.
-        """
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = Mock(returncode=0, stdout="Full RELRO")
-
-            report = ExecutableReport(path="/test/binary")
-            recon.run("/test/binary", report)
-
-            # Verify subprocess.run was called with correct format
-            mock_run.assert_called_once()
-            call_args = mock_run.call_args[0][0]  # Get the command list
-
-            # Should be ["checksec", "--file=/test/binary"], not ["checksec", "--file", "/test/binary"]
-            assert len(call_args) == 2, f"Expected 2 arguments, got {len(call_args)}: {call_args}"
-            assert call_args[0] == "checksec"
-            assert call_args[1].startswith("--file="), f"Expected --file=<path>, got {call_args[1]}"
-            assert call_args[1] == "--file=/test/binary"
-
-    @pytest.mark.integration
-    @pytest.mark.requires_checksec
-    def test_checksec_with_real_binary(self, recon):
-        """Test checksec command with a real system binary.
-
-        This test verifies that checksec is called correctly and can analyze
-        a real binary without errors. Requires checksec to be installed.
-        """
-        import shutil
-
-        if not shutil.which("checksec"):
-            pytest.skip("checksec not installed")
-
-        # Use /bin/ls as it's available on all systems
-        report = ExecutableReport(path="/bin/ls")
-        result = recon.run("/bin/ls", report)
-
-        # Should successfully detect protections
-        assert result.protections is not None
-        assert result.protections.relro != "checksec_error"
-        assert result.protections.relro != "checksec_not_found"
-        # /bin/ls typically has at least NX enabled on modern systems
-        assert result.protections.nx is True
 
     @pytest.mark.integration
     def test_real_test_binary_no_pie(self, recon, test_binaries_dir):
@@ -176,18 +185,11 @@ No RELRO        No canary found   NX disabled   No PIE          No RPATH   No RU
         assert result.protections.nx is True or result.protections.relro != "Unknown"
 
     @pytest.mark.integration
-    @pytest.mark.requires_checksec
     def test_real_test_binary_with_pie(self, recon, test_binaries_dir):
         """Test with real test_with_pie binary (full protections)."""
         binary_path = test_binaries_dir / "test_with_pie"
         if not binary_path.exists():
             pytest.skip("test_with_pie binary not available")
-
-        # Check if checksec is available
-        import shutil
-
-        if not shutil.which("checksec"):
-            pytest.skip("checksec not installed")
 
         report = ExecutableReport(path=str(binary_path))
         result = recon.run(str(binary_path), report)


### PR DESCRIPTION
Summary:\n- Replace external 'file' and 'checksec' tools with pyelftools-based implementations for FileInfoRecon and ProtectionsRecon.\n- Update docs and tests to remove checksec/file references.\n- Tests: 164 passed, 33 skipped.\n\nThis improves Windows compatibility and reduces external tool dependencies.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>