### PR TITLE
feat: improve R2 disassembly view for reverse engineers

### DIFF
--- a/caspoon/gui/views/r2_view.py
+++ b/caspoon/gui/views/r2_view.py
@@ -1,4 +1,4 @@
-"""R2 Analysis view — disassembly pane with syntax highlighting."""
+"""R2 Analysis view — disassembly pane with search/filter and syntax highlighting."""
 
 import re
 
@@ -6,17 +6,24 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import (
     QColor,
     QFont,
+    QKeySequence,
     QSyntaxHighlighter,
     QTextCharFormat,
+    QTextCursor,
 )
 from PySide6.QtWidgets import (
+    QApplication,
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMenu,
     QPlainTextEdit,
-    QSplitter,
+    QShortcut,
     QVBoxLayout,
     QWidget,
 )
 
-# Reuse classification logic from the existing syntax module
 from caspoon.ui.syntax.instructions import get_instruction_type
 from caspoon.ui.syntax.schemes import InstructionType
 
@@ -41,7 +48,6 @@ class AsmQHighlighter(QSyntaxHighlighter):
     }
 
     _ADDRESS_PAT = re.compile(r'0x[0-9a-fA-F]+')
-    # Match the leading mnemonic token on a line (optionally preceded by an address)
     _MNEMONIC_PAT = re.compile(r'^\s*(?:0x[0-9a-fA-F]+\s+)?\S+\s+(\w+)')
 
     def __init__(self, document=None) -> None:
@@ -56,18 +62,20 @@ class AsmQHighlighter(QSyntaxHighlighter):
         return fmt
 
     def highlightBlock(self, text: str) -> None:
-        # 1. Highlight hex addresses first (lower priority)
+        # 1. Highlight hex addresses (lower priority)
         for m in self._ADDRESS_PAT.finditer(text):
             self.setFormat(m.start(), m.end() - m.start(), self._fmt("#b5cea8"))
 
-        # 2. Classify and highlight the first mnemonic on the line
+        # 2. Classify and highlight the mnemonic
         tokens = text.strip().split()
         if not tokens:
             return
-        # Skip a leading address token like "0x1234:" or "0x1234"
+        # Skip a leading address token and byte-string token
         idx = 0
-        if tokens[0].startswith("0x") or tokens[0].rstrip(":").startswith("0x"):
-            idx = 1
+        if tokens[idx].startswith("0x"):
+            idx += 1
+        if idx < len(tokens) and re.fullmatch(r'[0-9a-fA-F]+', tokens[idx]):
+            idx += 1
         if idx >= len(tokens):
             return
 
@@ -75,21 +83,80 @@ class AsmQHighlighter(QSyntaxHighlighter):
         instr_type = get_instruction_type(mnemonic)
         color = self._INSTR_COLOR.get(instr_type, "#d4d4d4")
 
-        # Find the mnemonic's position in the raw text
         start = text.lower().find(mnemonic, text.find(tokens[0]))
         if start >= 0:
             self.setFormat(start, len(mnemonic), self._fmt(color, bold=True))
 
 
+class _DisasmEdit(QPlainTextEdit):
+    """QPlainTextEdit with a custom right-click context menu."""
+
+    _ADDR_PAT = re.compile(r'0x[0-9a-fA-F]+')
+
+    def contextMenuEvent(self, event) -> None:
+        menu: QMenu = self.createStandardContextMenu()
+
+        cursor = self.cursorForPosition(event.pos())
+        cursor.select(QTextCursor.SelectionType.LineUnderCursor)
+        line = cursor.selectedText()
+
+        sep = menu.insertSeparator(menu.actions()[0])
+
+        copy_addr = menu.addAction("Copy Address")
+        copy_line = menu.addAction("Copy Line")
+        menu.insertAction(sep, copy_addr)
+        menu.insertAction(sep, copy_line)
+
+        action = menu.exec(event.globalPos())
+
+        if action == copy_addr:
+            m = self._ADDR_PAT.search(line)
+            if m:
+                QApplication.clipboard().setText(m.group())
+        elif action == copy_line:
+            QApplication.clipboard().setText(line)
+
+
 class R2View(QWidget):
-    """Disassembly viewer backed by QPlainTextEdit + AsmQHighlighter."""
+    """Disassembly viewer with search/filter toolbar and syntax highlighting."""
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
+        self._instructions: list[dict] = []
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
 
-        self._disasm = QPlainTextEdit()
+        # --- Toolbar ---
+        toolbar = QWidget()
+        toolbar_layout = QHBoxLayout(toolbar)
+        toolbar_layout.setContentsMargins(4, 4, 4, 4)
+        toolbar_layout.setSpacing(6)
+
+        self._search = QLineEdit()
+        self._search.setPlaceholderText("Search disassembly…")
+        toolbar_layout.addWidget(self._search)
+
+        self._type_combo = QComboBox()
+        self._type_combo.addItem("All Types",   None)
+        self._type_combo.addItem("Call",        InstructionType.CALL)
+        self._type_combo.addItem("Jump",        InstructionType.JUMP)
+        self._type_combo.addItem("Return",      InstructionType.RETURN)
+        self._type_combo.addItem("Move",        InstructionType.MOVE)
+        self._type_combo.addItem("Arithmetic",  InstructionType.ARITHMETIC)
+        self._type_combo.addItem("Logic",       InstructionType.LOGIC)
+        self._type_combo.addItem("Stack",       InstructionType.STACK)
+        self._type_combo.addItem("Compare",     InstructionType.COMPARE)
+        toolbar_layout.addWidget(self._type_combo)
+
+        self._count_label = QLabel("0 / 0 instructions")
+        toolbar_layout.addWidget(self._count_label)
+
+        layout.addWidget(toolbar)
+
+        # --- Disassembly editor ---
+        self._disasm = _DisasmEdit()
         self._disasm.setReadOnly(True)
         font = QFont("Consolas", 10)
         font.setFixedPitch(True)
@@ -97,6 +164,17 @@ class R2View(QWidget):
         self._highlighter = AsmQHighlighter(self._disasm.document())
 
         layout.addWidget(self._disasm)
+
+        # --- Connections ---
+        self._search.textChanged.connect(self._apply_filter)
+        self._type_combo.currentIndexChanged.connect(self._apply_filter)
+
+        # Ctrl+F focuses the search box
+        QShortcut(QKeySequence("Ctrl+F"), self, self._search.setFocus)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     def set_data(self, raw_backend_data: dict | None) -> None:
         """Populate the disassembly pane from backend data.
@@ -106,22 +184,71 @@ class R2View(QWidget):
                 ``ExecutableReport`` (may be None).
         """
         if not raw_backend_data:
+            self._instructions = []
             self._disasm.setPlainText("No R2 data available.")
+            self._update_count(0)
             return
 
         disasm = raw_backend_data.get("disassembly")
         if not disasm:
+            self._instructions = []
             self._disasm.setPlainText("No disassembly data available.")
+            self._update_count(0)
             return
 
         if isinstance(disasm, list):
-            lines = disasm[:500]
-            self._disasm.setPlainText("\n".join(str(l) for l in lines))
+            self._instructions = [op for op in disasm if isinstance(op, dict)]
         elif isinstance(disasm, str):
+            # Plain-text fallback — no structured filtering possible
+            self._instructions = []
             self._disasm.setPlainText(disasm)
+            self._update_count(0)
+            return
         else:
+            self._instructions = []
             self._disasm.setPlainText(str(disasm))
+            self._update_count(0)
+            return
+
+        self._apply_filter()
 
     def clear(self) -> None:
-        """Clear the disassembly pane."""
+        """Clear the disassembly pane and reset filters."""
+        self._instructions = []
         self._disasm.clear()
+        self._update_count(0)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _fmt_op(op: dict) -> str:
+        """Format one instruction dict as a display line."""
+        addr = op.get("offset", 0)
+        raw_bytes = op.get("bytes", "")
+        disasm = op.get("disasm", "")
+        return f"0x{addr:08x}  {raw_bytes:<12}  {disasm}"
+
+    def _matches(self, op: dict, text: str, type_filter: InstructionType | None) -> bool:
+        """Return True if *op* passes both the text and type filters."""
+        if type_filter is not None:
+            mnemonic = op.get("disasm", "").split()[0] if op.get("disasm") else ""
+            if get_instruction_type(mnemonic.lower()) != type_filter:
+                return False
+        if text:
+            line = self._fmt_op(op).lower()
+            if text not in line:
+                return False
+        return True
+
+    def _apply_filter(self) -> None:
+        text = self._search.text().lower()
+        type_filter = self._type_combo.currentData()
+        filtered = [op for op in self._instructions if self._matches(op, text, type_filter)]
+        self._disasm.setPlainText("\n".join(self._fmt_op(op) for op in filtered))
+        self._update_count(len(filtered))
+
+    def _update_count(self, visible: int) -> None:
+        total = len(self._instructions)
+        self._count_label.setText(f"{visible:,} / {total:,} instructions")

--- a/caspoon/ui/__init__.py
+++ b/caspoon/ui/__init__.py
@@ -1,0 +1,1 @@
+"""UI utilities package."""

--- a/caspoon/ui/syntax/__init__.py
+++ b/caspoon/ui/syntax/__init__.py
@@ -1,0 +1,6 @@
+"""Assembly syntax highlighting and instruction classification."""
+
+from .instructions import get_instruction_type
+from .schemes import InstructionType
+
+__all__ = ["get_instruction_type", "InstructionType"]

--- a/caspoon/ui/syntax/instructions.py
+++ b/caspoon/ui/syntax/instructions.py
@@ -1,0 +1,124 @@
+"""Instruction classification for x86/x64 assembly mnemonics."""
+
+from .schemes import InstructionType
+
+X86_64_INSTRUCTIONS: dict[InstructionType, set[str]] = {
+    InstructionType.JUMP: {
+        'jmp', 'jmpq', 'jmpl', 'jmpw',
+        'je', 'jz', 'jne', 'jnz',
+        'jg', 'jnle', 'jge', 'jnl',
+        'jl', 'jnge', 'jle', 'jng',
+        'ja', 'jnbe', 'jae', 'jnb', 'jnc',
+        'jb', 'jnae', 'jc', 'jbe', 'jna',
+        'jo', 'jno', 'js', 'jns',
+        'jp', 'jpe', 'jnp', 'jpo',
+        'jcxz', 'jecxz', 'jrcxz',
+        'loop', 'loope', 'loopz', 'loopne', 'loopnz',
+    },
+    InstructionType.CALL: {
+        'call', 'callq', 'calll', 'callw',
+    },
+    InstructionType.RETURN: {
+        'ret', 'retq', 'retl', 'retw', 'retn',
+        'retf', 'retfq', 'retfl', 'retfw',
+        'iret', 'iretd', 'iretq',
+    },
+    InstructionType.MOVE: {
+        'mov', 'movq', 'movl', 'movw', 'movb',
+        'movzx', 'movzb', 'movzw', 'movzl', 'movzq',
+        'movsx', 'movsxd', 'movsbq', 'movswq', 'movslq',
+        'lea', 'leaq', 'leal', 'leaw',
+        'xchg', 'xchgq', 'xchgl', 'xchgw', 'xchgb',
+        'cmove', 'cmovz', 'cmovne', 'cmovnz',
+        'cmovg', 'cmovge', 'cmovl', 'cmovle',
+        'cmova', 'cmovae', 'cmovb', 'cmovbe',
+        'cmovo', 'cmovno', 'cmovs', 'cmovns',
+        'cmovp', 'cmovnp',
+        'sete', 'setz', 'setne', 'setnz',
+        'setg', 'setge', 'setl', 'setle',
+        'seta', 'setae', 'setb', 'setbe',
+        'seto', 'setno', 'sets', 'setns',
+        'setp', 'setnp',
+    },
+    InstructionType.ARITHMETIC: {
+        'add', 'addq', 'addl', 'addw', 'addb',
+        'adc', 'adcq', 'adcl', 'adcw', 'adcb',
+        'sub', 'subq', 'subl', 'subw', 'subb',
+        'sbb', 'sbbq', 'sbbl', 'sbbw', 'sbbb',
+        'mul', 'mulq', 'mull', 'mulw', 'mulb',
+        'imul', 'imulq', 'imull', 'imulw', 'imulb',
+        'div', 'divq', 'divl', 'divw', 'divb',
+        'idiv', 'idivq', 'idivl', 'idivw', 'idivb',
+        'inc', 'incq', 'incl', 'incw', 'incb',
+        'dec', 'decq', 'decl', 'decw', 'decb',
+        'neg', 'negq', 'negl', 'negw', 'negb',
+        'cbw', 'cwde', 'cdqe', 'cwd', 'cdq', 'cqo',
+    },
+    InstructionType.LOGIC: {
+        'and', 'andq', 'andl', 'andw', 'andb',
+        'or', 'orq', 'orl', 'orw', 'orb',
+        'xor', 'xorq', 'xorl', 'xorw', 'xorb',
+        'not', 'notq', 'notl', 'notw', 'notb',
+        'shl', 'shlq', 'shll', 'shlw', 'shlb',
+        'sal', 'salq', 'sall', 'salw', 'salb',
+        'shr', 'shrq', 'shrl', 'shrw', 'shrb',
+        'sar', 'sarq', 'sarl', 'sarw', 'sarb',
+        'rol', 'rolq', 'roll', 'rolw', 'rolb',
+        'ror', 'rorq', 'rorl', 'rorw', 'rorb',
+        'rcl', 'rclq', 'rcll', 'rclw', 'rclb',
+        'rcr', 'rcrq', 'rcrl', 'rcrw', 'rcrb',
+        'bt', 'btq', 'btl', 'btw',
+        'bts', 'btsq', 'btsl', 'btsw',
+        'btr', 'btrq', 'btrl', 'btrw',
+        'btc', 'btcq', 'btcl', 'btcw',
+        'bsf', 'bsfq', 'bsfl', 'bsfw',
+        'bsr', 'bsrq', 'bsrl', 'bsrw',
+        'bswap', 'bswapq', 'bswapl',
+    },
+    InstructionType.STACK: {
+        'push', 'pushq', 'pushl', 'pushw', 'pushb',
+        'pop', 'popq', 'popl', 'popw', 'popb',
+        'pusha', 'pushad', 'popa', 'popad',
+        'pushf', 'pushfq', 'pushfd', 'pushfw',
+        'popf', 'popfq', 'popfd', 'popfw',
+        'enter', 'enterq', 'enterl',
+        'leave', 'leaveq', 'leavel',
+    },
+    InstructionType.COMPARE: {
+        'cmp', 'cmpq', 'cmpl', 'cmpw', 'cmpb',
+        'test', 'testq', 'testl', 'testw', 'testb',
+    },
+    InstructionType.OTHER: {
+        'nop', 'nopq', 'nopl', 'nopw',
+        'ud2', 'ud2a', 'ud2b',
+        'cpuid', 'rdtsc', 'rdtscp', 'rdpmc',
+        'rdmsr', 'wrmsr',
+        'clc', 'stc', 'cmc', 'cld', 'std', 'cli', 'sti',
+        'lds', 'les', 'lfs', 'lgs', 'lss',
+        'lgdt', 'sgdt', 'lidt', 'sidt',
+        'lldt', 'sldt', 'ltr', 'str',
+        'xlat', 'xlatb', 'bound',
+        'int', 'int3', 'into',
+        'syscall', 'sysret', 'sysenter', 'sysexit',
+        'hlt',
+        'lfence', 'sfence', 'mfence',
+        'lock',
+        'monitor', 'mwait',
+    },
+}
+
+
+def get_instruction_type(mnemonic: str) -> InstructionType:
+    """Return the InstructionType for a given mnemonic string.
+
+    Args:
+        mnemonic: Instruction mnemonic (case-insensitive).
+
+    Returns:
+        Matching InstructionType, or InstructionType.OTHER if unrecognised.
+    """
+    mnemonic = mnemonic.lower().strip()
+    for instr_type, mnemonics in X86_64_INSTRUCTIONS.items():
+        if mnemonic in mnemonics:
+            return instr_type
+    return InstructionType.OTHER

--- a/caspoon/ui/syntax/schemes.py
+++ b/caspoon/ui/syntax/schemes.py
@@ -1,0 +1,17 @@
+"""Color schemes for assembly syntax highlighting."""
+
+from enum import Enum
+
+
+class InstructionType(Enum):
+    """Types of assembly instructions for syntax highlighting."""
+
+    JUMP = "jump"
+    CALL = "call"
+    MOVE = "move"
+    ARITHMETIC = "arithmetic"
+    LOGIC = "logic"
+    STACK = "stack"
+    COMPARE = "compare"
+    RETURN = "return"
+    OTHER = "other"


### PR DESCRIPTION
## Summary

- **Fix instruction formatting**: instructions now render as `0xADDR  BYTES  DISASM` (e.g. `0x00401000  55            push rbp`) instead of raw Python repr dicts
- **Add search/filter toolbar**: live text search (QLineEdit), instruction type filter (QComboBox: All/Call/Jump/Return/Move/Arithmetic/Logic/Stack/Compare), and a match-count label (`45 / 200 instructions`)
- **Add Ctrl+F shortcut** to focus the search box without reaching for the mouse
- **Add right-click context menu** on the disassembly pane with "Copy Address" and "Copy Line" actions
- **Create `caspoon/ui/syntax/` package** (`schemes.py` + `instructions.py`) — `r2_view.py` already imported from these modules but they were missing from the source tree

## Test plan

- [ ] Open the app and load a binary with r2 available
- [ ] Switch to "R2 Analysis" tab — instructions display as `0xADDR  BYTES  DISASM`, not raw dicts
- [ ] Type `call` in the search box — only call instructions remain, count label updates
- [ ] Select "Jump" from the type dropdown — filtered to jumps only, count updates
- [ ] Select "All Types" — all instructions return
- [ ] Press Ctrl+F — search box gains focus
- [ ] Right-click a line — context menu shows "Copy Address" and "Copy Line" actions
- [ ] Clear filters — all instructions return

🤖 Generated with [Claude Code](https://claude.com/claude-code)